### PR TITLE
OPP-767 Ikke send tomme fnr til kall i aktørregisteret

### DIFF
--- a/js/sagas/aktorSaga.js
+++ b/js/sagas/aktorSaga.js
@@ -14,6 +14,7 @@ export function* aktorSaga(action) {
     }
     if (!action.data.fnr || action.data.fnr.length === 0) {
         yield put(actions.hentAktorFeilet());
+        return;
     }
 
     try {

--- a/js/sagas/aktorSaga.js
+++ b/js/sagas/aktorSaga.js
@@ -12,6 +12,9 @@ export function* aktorSaga(action) {
         yield put(actions.aktorHentet(mockAktor));
         return;
     }
+    if (!action.data.fnr || action.data.fnr.length === 0) {
+        yield put(actions.hentAktorFeilet());
+    }
 
     try {
         const data = yield call(getWithHeaders, action.data.url, action.data.fnr);


### PR DESCRIPTION
Fra Jira:
Team Register får en del ekstra kall sidan dekoratøren kaller aktørId-rest-tjeneste uten personID-elementet., dette er ønskeleg at blir rydda opp i da det generer uønska trafikk og belastning.