### PR TITLE
[KAIZEN-0] la til `autoSubmit`

### DIFF
--- a/v2/src/application.tsx
+++ b/v2/src/application.tsx
@@ -28,7 +28,7 @@ export interface Props {
 
     onEnhetChange(enhet: string): void;
     contextholder?: true | Contextholder;
-    autoSubmit?: boolean;
+    autoSubmitOnMount?: boolean;
     urler?: {
         aktoerregister?: string;
     }
@@ -50,7 +50,7 @@ export interface Context {
     feilmelding: WrappedState<MaybeCls<string>>;
     apen: WrappedState<boolean>;
     contextholder: MaybeCls<Contextholder>;
-    autoSubmit: boolean;
+    autoSubmitOnMount: boolean;
 }
 
 export const AppContext = React.createContext<Context>({
@@ -71,11 +71,11 @@ export const AppContext = React.createContext<Context>({
     feilmelding: emptyWrappedState(MaybeCls.nothing()),
     apen: emptyWrappedState(false),
     contextholder: MaybeCls.nothing(),
-    autoSubmit: false
+    autoSubmitOnMount: false
 });
 
 function Application(props: Props) {
-    const { fnr, enhet, markup, autoSubmit, ...rest } = props;
+    const { fnr, enhet, markup, autoSubmitOnMount, ...rest } = props;
 
     const maybeFnr = useMemo(() => MaybeCls.of(fnr).filter((fnr) => fnr.length > 0), [fnr]);
     const maybeEnhet = useMemo(() => MaybeCls.of(enhet).filter((fnr) => fnr.length > 0), [enhet]);
@@ -111,7 +111,7 @@ function Application(props: Props) {
         apen,
         markupEttersokefelt,
         contextholder,
-        autoSubmit: autoSubmit || false
+        autoSubmitOnMount: autoSubmitOnMount || false
     };
 
     const ref = useRef(null);

--- a/v2/src/application.tsx
+++ b/v2/src/application.tsx
@@ -28,6 +28,7 @@ export interface Props {
 
     onEnhetChange(enhet: string): void;
     contextholder?: true | Contextholder;
+    autoSubmit?: boolean;
     urler?: {
         aktoerregister?: string;
     }
@@ -49,6 +50,7 @@ export interface Context {
     feilmelding: WrappedState<MaybeCls<string>>;
     apen: WrappedState<boolean>;
     contextholder: MaybeCls<Contextholder>;
+    autoSubmit: boolean;
 }
 
 export const AppContext = React.createContext<Context>({
@@ -68,11 +70,12 @@ export const AppContext = React.createContext<Context>({
     aktorId: emptyFetchState,
     feilmelding: emptyWrappedState(MaybeCls.nothing()),
     apen: emptyWrappedState(false),
-    contextholder: MaybeCls.nothing()
+    contextholder: MaybeCls.nothing(),
+    autoSubmit: false
 });
 
 function Application(props: Props) {
-    const { fnr, enhet, markup, ...rest } = props;
+    const { fnr, enhet, markup, autoSubmit, ...rest } = props;
 
     const maybeFnr = useMemo(() => MaybeCls.of(fnr).filter((fnr) => fnr.length > 0), [fnr]);
     const maybeEnhet = useMemo(() => MaybeCls.of(enhet).filter((fnr) => fnr.length > 0), [enhet]);
@@ -107,7 +110,8 @@ function Application(props: Props) {
         feilmelding,
         apen,
         markupEttersokefelt,
-        contextholder
+        contextholder,
+        autoSubmit: autoSubmit || false
     };
 
     const ref = useRef(null);

--- a/v2/src/components/sokefelt.tsx
+++ b/v2/src/components/sokefelt.tsx
@@ -28,7 +28,7 @@ function useOnMount(effect: EffectCallback) {
 
 function Sokefelt() {
     const context = useContext(AppContext);
-    const autoSubmit = context.autoSubmit;
+    const autoSubmitOnMount = context.autoSubmitOnMount;
     const fnr = context.fnr.withDefault('');
     const sokefelt = useFieldState(fnr);
     const sokefeltRef = useRef<HTMLInputElement>(null);
@@ -63,7 +63,7 @@ function Sokefelt() {
 
     useHotkeys(useCallback(lagHotkeys, [sokefeltRef, reset])(sokefeltRef, reset));
     useOnMount(() => {
-        if (autoSubmit && fnr.length > 0) {
+        if (autoSubmitOnMount && fnr.length > 0) {
             eventlessOnSubmit();
         }
     });

--- a/v2/src/components/sokefelt.tsx
+++ b/v2/src/components/sokefelt.tsx
@@ -1,7 +1,7 @@
-import React, {RefObject, useCallback, useContext, useLayoutEffect, useRef} from 'react';
-import { AppContext } from '../application';
+import React, {EffectCallback, RefObject, useCallback, useContext, useEffect, useRef} from 'react';
+import {AppContext} from '../application';
 import useFieldState from '../hooks/use-field-state';
-import { lagFnrFeilmelding } from '../utils/fnr-utils';
+import {lagFnrFeilmelding} from '../utils/fnr-utils';
 import useHotkeys, {erAltOg} from "../hooks/use-hotkeys";
 import {nullstillAktivBruker} from "../context-api";
 
@@ -20,6 +20,10 @@ function lagHotkeys(ref: RefObject<HTMLInputElement>, reset: () => void) {
             execute: reset
         }
     ];
+}
+
+function useOnMount(effect: EffectCallback) {
+    useEffect(effect, []);
 }
 
 function Sokefelt() {
@@ -58,11 +62,11 @@ function Sokefelt() {
     };
 
     useHotkeys(useCallback(lagHotkeys, [sokefeltRef, reset])(sokefeltRef, reset));
-    useLayoutEffect(() => {
+    useOnMount(() => {
         if (autoSubmit && fnr.length > 0) {
             eventlessOnSubmit();
         }
-    } ,[]);
+    });
 
     return (
         <section>

--- a/v2/src/hooks/use-contextholder.ts
+++ b/v2/src/hooks/use-contextholder.ts
@@ -9,10 +9,11 @@ import log from './../utils/logging';
 import { WrappedState } from './use-wrapped-state';
 import {
     AKTIV_BRUKER_URL,
-    AKTIV_ENHET_URL,
+    AKTIV_ENHET_URL, nullstillAktivBruker,
     oppdaterAktivBruker,
     oppdaterAktivEnhet
 } from '../context-api';
+import {lagFnrFeilmelding} from "../utils/fnr-utils";
 
 function useInitialEnhetSync(
     syncingEnhet: MutableRefObject<boolean>,
@@ -136,12 +137,16 @@ function useInitialFnrSync(
                 fnr.map2((fnr, { aktivBruker }) => {
                     if (!syncingFnr.current && fnr !== aktivBruker) {
                         syncingFnr.current = true;
-                        oppdaterAktivBruker(fnr)
-                            .then(() => setFnrSynced(true))
-                            .then(aktivBrukerRefretch)
-                            .then(() => {
-                                syncingFnr.current = false;
-                            });
+                        if (lagFnrFeilmelding(fnr).isNothing()) {
+                            oppdaterAktivBruker(fnr)
+                                .then(() => setFnrSynced(true))
+                                .then(aktivBrukerRefretch)
+                                .then(() => {
+                                    syncingFnr.current = false;
+                                });
+                        } else {
+                            nullstillAktivBruker()
+                        }
                     }
                 }, aktivBrukerData);
             }


### PR DESCRIPTION
gjor at sok automatisk gjennomfores ved mounting av componenten om
fnr er definert og autoSubmit er satt til true.

By default er den satt til false, slik at det ikke har noen effekt for
eksisterende konsumenter