### PR TITLE
[FAGSYSTEM-93490] fikser mismatch mellom V1 og V2 mtp lenke-oppsett

### DIFF
--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -4,11 +4,12 @@ import {finnMiljoStreng, finnNaisMiljoStreng} from '../utils/url-utils';
 import { AppContext } from '../application';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 
-function Lenke(props: { href: string; children: string }) {
+function Lenke(props: { href: string; children: string; target?: string; }) {
     /* eslint-disable jsx-a11y/anchor-has-content */
+    const rel = props.target ? 'noopener noreferrer' : undefined;
     return (
         <li>
-            <a {...props} className="typo-normal dekorator__menylenke" target={'_blank'} rel={'noopener noreferrer'} />
+            <a {...props} className="typo-normal dekorator__menylenke" rel={rel} />
         </li>
     );
     /* eslint-enable jsx-a11y/anchor-has-content */
@@ -161,23 +162,23 @@ function Lenker() {
                 <section className="dekorator__rad">
                     <h2 className="dekorator__lenkeheader">Andre systemer</h2>
                     <ul className="dekorator__menyliste">
-                        <Lenke href={arenaUrl(fnr)}>
+                        <Lenke href={arenaUrl(fnr)} target="_blank">
                             Arena personmappen
                         </Lenke>
-                        <Lenke href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)}>
+                        <Lenke href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)} target="_blank">
                             AA register
                         </Lenke>
-                        <Lenke href={pesysUrl(fnr, `/psak/brukeroversikt/fnr=${fnr}`)}>Pesys</Lenke>
-                        <Lenke href={gosysUrl(fnr, `/gosys/personoversikt/fnr=${fnr}`)}>
+                        <Lenke href={pesysUrl(fnr, `/psak/brukeroversikt/fnr=${fnr}`)} target="_blank">Pesys</Lenke>
+                        <Lenke href={gosysUrl(fnr, `/gosys/personoversikt/fnr=${fnr}`)} target="_blank">
                             Gosys
                         </Lenke>
-                        <Lenke href={foreldrePengerUrl(aktorId, `/fpsak/aktoer/${aktorId}`)}>
+                        <Lenke href={foreldrePengerUrl(aktorId, `/fpsak/aktoer/${aktorId}`)} target="_blank">
                             Foreldrepenger
                         </Lenke>
-                        <Lenke href={`https://rekrutteringsbistand${naisDomain}`}>
+                        <Lenke href={`https://rekrutteringsbistand${naisDomain}`} target="_blank">
                             Rekrutteringsbistand
                         </Lenke>
-                        <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillinger`}>
+                        <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillinger`} target="_blank">
                             Søk etter stilling
                         </Lenke>
                     </ul>


### PR DESCRIPTION
V1-versjonen åpner bare lenker til "Andre systemer" i ny fane, men lenker innad i "modia" (personoversikt, arbeidsrettet oppfølging og sykefraværsoppfølging) åpnes i samme fane.

V2 hadde derimot `target="_blank"` på alle lenkene i menyen. Denne endringen gjør om det dette slik at meny-oppsettene er like på tvers av versjoner.