### PR TITLE
[KAIZEN-0] Oppdaterer URL til Manuell Registrering

### DIFF
--- a/js/menyConfig.js
+++ b/js/menyConfig.js
@@ -24,7 +24,7 @@ function getArenaStartsideLink() {
 }
 
 function byggArbeidssokerregistreringsURL(fnr, enhet) {
-    return `https://arbeidssokerregistrering-fss${finnMiljoStreng()}${naisDomain}?${fnr ? `fnr=${fnr}` : ''}${fnr && enhet ? '&' : ''}${enhet ? `enhetId=${enhet}` : ''}`;
+    return `https://arbeidssokerregistrering${finnMiljoStreng()}${naisDomain}?${fnr ? `fnr=${fnr}` : ''}${fnr && enhet ? '&' : ''}${enhet ? `enhetId=${enhet}` : ''}`;
 }
 
 export const funksjonsomradeLenker = (fnr, enhet) => [


### PR DESCRIPTION
Ny URL er støttet i Registreringstjenesten: https://github.com/navikt/arbeidssokerregistrering/blob/master/nais/vars-p-fss.yaml

Ingen eller mange URLer i dekoratøren fungerer ikke fra Manuell Registrering fordi URLene utledes fra host som nå inneholder `-fss`. Det håndterer ikke konfigurasjonen og derfor blir `-fss` injecta inn i de andre URLene i dekoratøren.