### PR TITLE
Feat/controlledapi

### DIFF
--- a/v2.1/public/index.html
+++ b/v2.1/public/index.html
@@ -19,10 +19,10 @@
 <div id="root"></div>
 </body>
 <script>
-    const minimal = {
+    const minimal = () => ({
         appname: 'Modia basic'
-    };
-    const enhetAware = {
+    });
+    const enhetAware = () => ({
         appname: 'Modia enhet',
         enhet: {
             initialValue: '0604',
@@ -34,8 +34,8 @@
         toggles: {
             visEnhetVelger: true
         }
-    };
-    const fnrAware = {
+    });
+    const fnrAware = () => ({
         appname: 'Modia enhet',
         fnr: {
             initialValue: '10108000398',
@@ -47,14 +47,39 @@
         toggles: {
             visSokefelt: true
         }
-    };
-    const complete = {
+    });
+    const controlled = (fnrValue, enhetValue) => ({
+        appname: 'Modia controlled',
+        fnr: {
+            value: fnrValue,
+            display: 'SOKEFELT',
+            onChange(fnr) {
+                console.warn("FNR onChange", fnr);
+                render(fnr, enhetValue);
+            }
+        },
+        enhet: {
+            value: enhetValue,
+            display: 'ENHET_VALG',
+            onChange(enhet) {
+                console.warn("ENHET onChange", enhet);
+                render(fnrValue, enhet);
+            }
+        },
+        toggles: {
+            visVeileder: true
+        },
+        markup: {
+            etterSokefelt: '<button>Min knapp</button>',
+        }
+    });
+    const complete = () => ({
         appname: 'Modia maximum',
         fnr: {
             initialValue: '',
             display: 'SOKEFELT',
-            onChange(enhet) {
-                console.warn('FNR onChange', enhet);
+            onChange(fnr) {
+                console.warn('FNR onChange', fnr);
             }
         },
         enhet: {
@@ -69,13 +94,17 @@
         },
         markup: {
             etterSokefelt: '<button>Min knapp</button>',
-        },
-        contextholderConfig: {
-            enabled: true,
-            promptBeforeEnhetChange: true
         }
-    };
+    });
 
-    NAVSPA.internarbeidsflatefs(document.getElementById('root'), complete);
+    let appstate = { fnr: '\u0000', enhet: '' };
+    function renderDecorator(newConfig) {
+        appstate = { ...appstate, ...newConfig };
+        const config = controlled(appstate.fnr, appstate.enhet);
+        console.log('Rendering', config.fnr.initialValue || config.fnr.value, config.enhet.initialValue || config.enhet.value);
+        NAVSPA.internarbeidsflatefs(document.getElementById('root'), config);
+    }
+
+    renderDecorator();
 </script>
 </html>

--- a/v2.1/public/index.html
+++ b/v2.1/public/index.html
@@ -19,6 +19,7 @@
 <div id="root"></div>
 </body>
 <script>
+    let appstate = { fnr: '', enhet: null };
     const minimal = () => ({
         appname: 'Modia basic'
     });
@@ -97,11 +98,9 @@
         }
     });
 
-    let appstate = { fnr: '\u0000', enhet: '' };
     function renderDecorator(newConfig) {
         appstate = { ...appstate, ...newConfig };
-        const config = controlled(appstate.fnr, appstate.enhet);
-        console.log('Rendering', config.fnr.initialValue || config.fnr.value, config.enhet.initialValue || config.enhet.value);
+        const config = complete(appstate.fnr, appstate.enhet);
         NAVSPA.internarbeidsflatefs(document.getElementById('root'), config);
     }
 

--- a/v2.1/src/application.tsx
+++ b/v2.1/src/application.tsx
@@ -1,19 +1,19 @@
-import React, {useCallback, useRef} from 'react';
-import {Dispatch} from 'redux';
-import {Provider, useDispatch, useSelector} from 'react-redux';
-import store, {State} from './redux';
-import {SagaActions, SagaActionTypes} from './redux/actions';
-import {ApplicationProps} from './domain';
+import React, { useCallback, useRef } from 'react';
+import { Dispatch } from 'redux';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import store, { State } from './redux';
+import { SagaActions, SagaActionTypes } from './redux/actions';
+import { ApplicationProps } from './domain';
 import Banner from './components/banner';
 import Lenker from './components/lenker';
 import NyEnhetContextModal from './components/modals/ny-enhet-context-modal';
 import NyBrukerContextModal from './components/modals/ny-bruker-context-modal';
 import Feilmelding from './components/feilmelding';
-import {useWrappedState, WrappedState} from './hooks/use-wrapped-state';
+import { useWrappedState, WrappedState } from './hooks/use-wrapped-state';
 import useOnClickOutside from './hooks/use-on-click-outside';
-import {useOnMount} from './hooks/use-on-mount';
-import {useOnChanged} from "./hooks/use-on-changed";
-import {getContextvalueValue, isContextvalueControlled, RESET_VALUE} from "./redux/utils";
+import { useOnMount } from './hooks/use-on-mount';
+import { useOnChanged } from './hooks/use-on-changed';
+import { getContextvalueValue, isContextvalueControlled, RESET_VALUE } from './redux/utils';
 
 function Application(props: ApplicationProps) {
     const dispatch = useDispatch<Dispatch<SagaActions>>();
@@ -23,26 +23,32 @@ function Application(props: ApplicationProps) {
         dispatch({ type: SagaActionTypes.INIT, data: props });
     });
 
-    useOnChanged(() => getContextvalueValue(props.fnr), () => {
-        if (!isFnrControlled.current) {
-            return;
+    useOnChanged(
+        () => getContextvalueValue(props.fnr),
+        () => {
+            if (!isFnrControlled.current) {
+                return;
+            }
+            const nyFnr = getContextvalueValue(props.fnr);
+            if (nyFnr === null || nyFnr === RESET_VALUE || nyFnr.trim().length === 0) {
+                dispatch({ type: SagaActionTypes.FNRRESET });
+            } else {
+                dispatch({ type: SagaActionTypes.FNRSUBMIT, data: nyFnr });
+            }
         }
-        const nyFnr = getContextvalueValue(props.fnr);
-        if (nyFnr === null || nyFnr === RESET_VALUE || nyFnr.trim().length === 0) {
-            dispatch({ type: SagaActionTypes.FNRRESET });
-        } else {
-            dispatch({ type: SagaActionTypes.FNRSUBMIT, data: nyFnr });
+    );
+    useOnChanged(
+        () => getContextvalueValue(props.enhet),
+        () => {
+            if (!isEnhetControlled.current) {
+                return;
+            }
+            const nyEnhet = getContextvalueValue(props.enhet);
+            if (nyEnhet !== null) {
+                dispatch({ type: SagaActionTypes.ENHETCHANGED, data: nyEnhet });
+            }
         }
-    });
-    useOnChanged(() => getContextvalueValue(props.enhet), () => {
-        if (!isEnhetControlled.current) {
-            return;
-        }
-        const nyEnhet = getContextvalueValue(props.enhet);
-        if (nyEnhet !== null) {
-            dispatch({ type: SagaActionTypes.ENHETCHANGED, data: nyEnhet });
-        }
-    });
+    );
 
     const isInitialized = useSelector((state: State) => state.appdata.initialized);
 

--- a/v2.1/src/application.tsx
+++ b/v2.1/src/application.tsx
@@ -13,15 +13,20 @@ import {useWrappedState, WrappedState} from './hooks/use-wrapped-state';
 import useOnClickOutside from './hooks/use-on-click-outside';
 import {useOnMount} from './hooks/use-on-mount';
 import {useOnChanged} from "./hooks/use-on-changed";
-import {getContextvalueValue, RESET_VALUE} from "./redux/utils";
+import {getContextvalueValue, isContextvalueControlled, RESET_VALUE} from "./redux/utils";
 
 function Application(props: ApplicationProps) {
     const dispatch = useDispatch<Dispatch<SagaActions>>();
+    const isFnrControlled = useRef(isContextvalueControlled(props.fnr));
+    const isEnhetControlled = useRef(isContextvalueControlled(props.enhet));
     useOnMount(() => {
         dispatch({ type: SagaActionTypes.INIT, data: props });
     });
 
     useOnChanged(() => getContextvalueValue(props.fnr), () => {
+        if (!isFnrControlled.current) {
+            return;
+        }
         const nyFnr = getContextvalueValue(props.fnr);
         if (nyFnr === null || nyFnr === RESET_VALUE || nyFnr.trim().length === 0) {
             dispatch({ type: SagaActionTypes.FNRRESET });
@@ -30,6 +35,9 @@ function Application(props: ApplicationProps) {
         }
     });
     useOnChanged(() => getContextvalueValue(props.enhet), () => {
+        if (!isEnhetControlled.current) {
+            return;
+        }
         const nyEnhet = getContextvalueValue(props.enhet);
         if (nyEnhet !== null) {
             dispatch({ type: SagaActionTypes.ENHETCHANGED, data: nyEnhet });

--- a/v2.1/src/application.tsx
+++ b/v2.1/src/application.tsx
@@ -1,24 +1,41 @@
-import React, { useCallback, useRef } from 'react';
-import { Dispatch } from 'redux';
-import { Provider, useDispatch, useSelector } from 'react-redux';
-import store from './redux';
-import { SagaActions, SagaActionTypes } from './redux/actions';
-import { ApplicationProps } from './domain';
+import React, {useCallback, useRef} from 'react';
+import {Dispatch} from 'redux';
+import {Provider, useDispatch, useSelector} from 'react-redux';
+import store, {State} from './redux';
+import {SagaActions, SagaActionTypes} from './redux/actions';
+import {ApplicationProps} from './domain';
 import Banner from './components/banner';
 import Lenker from './components/lenker';
 import NyEnhetContextModal from './components/modals/ny-enhet-context-modal';
 import NyBrukerContextModal from './components/modals/ny-bruker-context-modal';
 import Feilmelding from './components/feilmelding';
-import { useWrappedState, WrappedState } from './hooks/use-wrapped-state';
+import {useWrappedState, WrappedState} from './hooks/use-wrapped-state';
 import useOnClickOutside from './hooks/use-on-click-outside';
-import { useOnMount } from './hooks/use-on-mount';
-import { State } from './redux';
+import {useOnMount} from './hooks/use-on-mount';
+import {useOnChanged} from "./hooks/use-on-changed";
+import {getContextvalueValue, RESET_VALUE} from "./redux/utils";
 
 function Application(props: ApplicationProps) {
     const dispatch = useDispatch<Dispatch<SagaActions>>();
     useOnMount(() => {
         dispatch({ type: SagaActionTypes.INIT, data: props });
     });
+
+    useOnChanged(() => getContextvalueValue(props.fnr), () => {
+        const nyFnr = getContextvalueValue(props.fnr);
+        if (nyFnr === null || nyFnr === RESET_VALUE || nyFnr.trim().length === 0) {
+            dispatch({ type: SagaActionTypes.FNRRESET });
+        } else {
+            dispatch({ type: SagaActionTypes.FNRSUBMIT, data: nyFnr });
+        }
+    });
+    useOnChanged(() => getContextvalueValue(props.enhet), () => {
+        const nyEnhet = getContextvalueValue(props.enhet);
+        if (nyEnhet !== null) {
+            dispatch({ type: SagaActionTypes.ENHETCHANGED, data: nyEnhet });
+        }
+    });
+
     const isInitialized = useSelector((state: State) => state.appdata.initialized);
 
     const apen: WrappedState<boolean> = useWrappedState(false);

--- a/v2.1/src/components/sokefelt.tsx
+++ b/v2.1/src/components/sokefelt.tsx
@@ -39,7 +39,7 @@ function Sokefelt() {
         const feilmelding = lagFnrFeilmelding(value);
 
         if (feilmelding.isJust()) {
-            const feilmeldingData = feilmelding.withDefault(PredefiniertFeilmeldinger.FNR_UKJENT_FEIL)
+            const feilmeldingData = feilmelding.withDefault(PredefiniertFeilmeldinger.FNR_UKJENT_FEIL);
             dispatch(leggTilFeilmelding(feilmeldingData));
         } else {
             dispatch(fjernFeilmelding(FeilmeldingKode.VALIDERING_FNR));

--- a/v2.1/src/components/sokefelt.tsx
+++ b/v2.1/src/components/sokefelt.tsx
@@ -8,7 +8,11 @@ import { lagFnrFeilmelding } from '../utils/fnr-utils';
 import visibleIf from './visibleIf';
 import { useFnrContextvalueState } from '../hooks/use-contextvalue-state';
 import { fjernFeilmelding, leggTilFeilmelding } from '../redux/feilmeldinger/reducer';
-import {FeilmeldingerActions, FeilmeldingKode, PredefiniertFeilmeldinger} from '../redux/feilmeldinger/domain';
+import {
+    FeilmeldingerActions,
+    FeilmeldingKode,
+    PredefiniertFeilmeldinger
+} from '../redux/feilmeldinger/domain';
 
 function lagHotkeys(ref: RefObject<HTMLInputElement>, reset: () => void) {
     return [
@@ -39,7 +43,9 @@ function Sokefelt() {
         const feilmelding = lagFnrFeilmelding(value);
 
         if (feilmelding.isJust()) {
-            const feilmeldingData = feilmelding.withDefault(PredefiniertFeilmeldinger.FNR_UKJENT_FEIL);
+            const feilmeldingData = feilmelding.withDefault(
+                PredefiniertFeilmeldinger.FNR_UKJENT_FEIL
+            );
             dispatch(leggTilFeilmelding(feilmeldingData));
         } else {
             dispatch(fjernFeilmelding(FeilmeldingKode.VALIDERING_FNR));

--- a/v2.1/src/components/veileder.tsx
+++ b/v2.1/src/components/veileder.tsx
@@ -6,11 +6,13 @@ import { EMDASH } from '../utils/string-utils';
 function Veileder() {
     const saksbehandler = useInitializedState((state) => state.data.saksbehandler);
 
-    const identElement = saksbehandler.map((data) => data.ident)
+    const identElement = saksbehandler
+        .map((data) => data.ident)
         .map((ident) => <span className="dekorator__hode__veileder_id">{ident}</span>)
         .withDefault(<span className="dekorator__hode__veileder_id">{EMDASH}</span>);
 
-    const navnElement = saksbehandler.map((data) => data.navn)
+    const navnElement = saksbehandler
+        .map((data) => data.navn)
         .map((navn) => <span className="dekorator__hode__veileder_navn">{navn}</span>)
         .withDefault(null);
 

--- a/v2.1/src/domain.ts
+++ b/v2.1/src/domain.ts
@@ -6,13 +6,21 @@ export interface Markup {
     etterSokefelt?: string;
 }
 
-export interface Contextvalue<T> {
+export interface ControlledContextvalue<T> extends BaseContextvalue<T> {
+    value: string | null;
+}
+export interface UncontrolledContextvalue<T> extends BaseContextvalue<T> {
     initialValue: string | null;
+}
+
+export interface BaseContextvalue<T> {
     display: T;
     onChange(value: string | null): void;
     skipModal?: boolean;
     ignoreWsEvents?: boolean;
 }
+
+export type Contextvalue<T> = ControlledContextvalue<T> | UncontrolledContextvalue<T>;
 
 export enum EnhetDisplay {
     ENHET = 'ENHET',

--- a/v2.1/src/hooks/use-on-changed.ts
+++ b/v2.1/src/hooks/use-on-changed.ts
@@ -1,4 +1,4 @@
-import {useEffect} from "react";
+import { useEffect } from 'react';
 
 export function useOnChanged(trigger: () => any, fn: () => void) {
     useEffect(fn, [trigger()]);

--- a/v2.1/src/hooks/use-on-changed.ts
+++ b/v2.1/src/hooks/use-on-changed.ts
@@ -1,0 +1,5 @@
+import {useEffect} from "react";
+
+export function useOnChanged(trigger: () => any, fn: () => void) {
+    useEffect(fn, [trigger()]);
+}

--- a/v2.1/src/mock/context-mock.ts
+++ b/v2.1/src/mock/context-mock.ts
@@ -56,6 +56,12 @@ function setupControls() {
         updateContext({ verdi: '0118', eventType: 'NY_AKTIV_ENHET' })
     );
 
+    const updateFnr = document.createElement('button');
+    updateFnr.innerText = 'App update Fnr 01011950120 (gutt)';
+    updateFnr.addEventListener('click', () =>
+        (window as any).renderDecorator({ fnr: '01011950120' })
+    );
+
     const clearBothLogs = document.createElement('button');
     clearBothLogs.innerText = 'Clear both logs';
     clearBothLogs.addEventListener('click', () => {
@@ -71,6 +77,7 @@ function setupControls() {
     buttonDiv.appendChild(jenteButton);
     buttonDiv.appendChild(barumEnhet);
     buttonDiv.appendChild(aremarkEnhet);
+    buttonDiv.appendChild(updateFnr);
     buttonDiv.appendChild(clearBothLogs);
 
     controlDiv.appendChild(buttonDiv);

--- a/v2.1/src/redux/actions.ts
+++ b/v2.1/src/redux/actions.ts
@@ -13,7 +13,6 @@ export enum ReduxActionTypes {
 export enum SagaActionTypes {
     INIT = 'SAGA/INIT',
     ENHETCHANGED = 'SAGA/ENHETCHANGED',
-    FNRCHANGED = 'SAGA/FNRCHANGED',
     FNRSUBMIT = 'SAGA/FNRSUBMIT',
     FNRRESET = 'SAGA/FNRRESET',
     WS_ENHET_DECLINE = 'SAGA/WS_ENHET_DECLINE',
@@ -28,9 +27,8 @@ export type AktorIdData = DataAction<ReduxActionTypes.AKTORIDDATA, AktorIdRespon
 
 export type SagaInit = DataAction<SagaActionTypes.INIT, ApplicationProps>;
 export type EnhetChanged = DataAction<SagaActionTypes.ENHETCHANGED, string>;
-export type FnrChanged = DataAction<SagaActionTypes.FNRCHANGED, string>;
 export type FnrSubmit = DataAction<SagaActionTypes.FNRSUBMIT, string>;
 export type FnrReset = Action<SagaActionTypes.FNRRESET>;
 
 export type ReduxActions = InitStore | UpdateStore | AktorIdData;
-export type SagaActions = SagaInit | EnhetChanged | FnrChanged | FnrSubmit | FnrReset;
+export type SagaActions = SagaInit | EnhetChanged | FnrSubmit | FnrReset;

--- a/v2.1/src/redux/enhet-initial-sync-saga.test.ts
+++ b/v2.1/src/redux/enhet-initial-sync-saga.test.ts
@@ -10,10 +10,10 @@ import initialSyncEnhet from './enhet-initial-sync-saga';
 import { AKTIV_BRUKER_URL, AKTIV_ENHET_URL, ContextApiType, modiacontextholderUrl } from './api';
 import { AktivBruker, AktivEnhet, AktorIdResponse, Enhet, Saksbehandler } from '../internal-domain';
 import { EnhetContextvalue, EnhetDisplay } from '../domain';
-import {RecursivePartial} from "./utils";
-import {State} from "./index";
-import {leggTilFeilmelding} from "./feilmeldinger/reducer";
-import {PredefiniertFeilmeldinger} from "./feilmeldinger/domain";
+import { RecursivePartial } from './utils';
+import { State } from './index';
+import { leggTilFeilmelding } from './feilmeldinger/reducer';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
 
 const mockSaksbehandler: Omit<Saksbehandler, 'enheter'> = {
     ident: '',
@@ -122,7 +122,9 @@ describe('saga - root', () => {
         const dispatched = await run(initialSyncEnhet, state, props);
 
         expect(dispatched).toHaveLength(1);
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET)
+        );
 
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
@@ -139,7 +141,9 @@ describe('saga - root', () => {
         const dispatched = await run(initialSyncEnhet, state, props);
 
         expect(dispatched).toHaveLength(1);
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET)
+        );
 
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
@@ -206,7 +210,9 @@ describe('saga - root', () => {
         const dispatched = await run(initialSyncEnhet, state, props);
 
         expect(dispatched).toHaveLength(1);
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET)
+        );
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
         expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
@@ -222,7 +228,9 @@ describe('saga - root', () => {
         const dispatched = await run(initialSyncEnhet, state, props);
 
         expect(dispatched).toHaveLength(1);
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.INGEN_GYLDIG_ENHET)
+        );
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
         expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();

--- a/v2.1/src/redux/enhet-initial-sync-saga.ts
+++ b/v2.1/src/redux/enhet-initial-sync-saga.ts
@@ -3,11 +3,16 @@ import { MaybeCls } from '@nutgaard/maybe-ts';
 import * as Api from './api';
 import { FetchResponse } from './api';
 import { AktivEnhet, Data, Enhet } from '../internal-domain';
-import {getContextvalueValue, RESET_VALUE, selectFromInitializedState, spawnConditionally} from './utils';
+import {
+    getContextvalueValue,
+    RESET_VALUE,
+    selectFromInitializedState,
+    spawnConditionally
+} from './utils';
 import { EnhetContextvalue } from '../domain';
 import { updateEnhetValue } from './enhet-update-sagas';
 import { leggTilFeilmelding } from './feilmeldinger/reducer';
-import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
 
 export default function* initialSyncEnhet(props: EnhetContextvalue) {
     if (getContextvalueValue(props) === RESET_VALUE) {

--- a/v2.1/src/redux/enhet-initial-sync-saga.ts
+++ b/v2.1/src/redux/enhet-initial-sync-saga.ts
@@ -3,14 +3,14 @@ import { MaybeCls } from '@nutgaard/maybe-ts';
 import * as Api from './api';
 import { FetchResponse } from './api';
 import { AktivEnhet, Data, Enhet } from '../internal-domain';
-import { RESET_VALUE, selectFromInitializedState, spawnConditionally } from './utils';
+import {getContextvalueValue, RESET_VALUE, selectFromInitializedState, spawnConditionally} from './utils';
 import { EnhetContextvalue } from '../domain';
 import { updateEnhetValue } from './enhet-update-sagas';
 import { leggTilFeilmelding } from './feilmeldinger/reducer';
 import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
 
 export default function* initialSyncEnhet(props: EnhetContextvalue) {
-    if (props.initialValue === RESET_VALUE) {
+    if (getContextvalueValue(props) === RESET_VALUE) {
         yield call(Api.nullstillAktivEnhet);
     }
     const response: FetchResponse<AktivEnhet> = yield call(Api.hentAktivEnhet);
@@ -21,7 +21,7 @@ export default function* initialSyncEnhet(props: EnhetContextvalue) {
         .withDefault<Array<Enhet>>([])
         .map((enhet) => enhet.enhetId);
 
-    const onsketEnhet = MaybeCls.of(props.initialValue)
+    const onsketEnhet = MaybeCls.of(getContextvalueValue(props))
         .map((enhet) => (enhet === RESET_VALUE ? '' : enhet))
         .map((enhet) => enhet.trim())
         .filter((enhet) => enhet.length > 0)

--- a/v2.1/src/redux/feilmeldinger/domain.ts
+++ b/v2.1/src/redux/feilmeldinger/domain.ts
@@ -20,7 +20,6 @@ export enum FeilmeldingActionTypes {
     FJERN = 'REDUX/FEILMELDING/FJERN'
 }
 
-
 export type PredefiniertFeilmelding = Feilmelding & { __final__: true };
 function definer(kode: FeilmeldingKode, melding: string): PredefiniertFeilmelding {
     return { kode, melding } as PredefiniertFeilmelding;
@@ -39,22 +38,13 @@ export const PredefiniertFeilmeldinger = {
         FeilmeldingKode.VALIDERING_FNR,
         'Fødselsnummeret må inneholde 11 siffer'
     ),
-    FNR_KUN_TALL: definer(
-        FeilmeldingKode.VALIDERING_FNR,
-        'Fødselsnummeret må kun inneholde tall'
-    ),
-    FNR_KONTROLL_SIFFER: definer(
-        FeilmeldingKode.VALIDERING_FNR,
-        'Fødselsnummeret er ikke gyldig'
-    ),
+    FNR_KUN_TALL: definer(FeilmeldingKode.VALIDERING_FNR, 'Fødselsnummeret må kun inneholde tall'),
+    FNR_KONTROLL_SIFFER: definer(FeilmeldingKode.VALIDERING_FNR, 'Fødselsnummeret er ikke gyldig'),
     FNR_UKJENT_FEIL: definer(
         FeilmeldingKode.UKJENT_VALIDERING_FNR,
         'Ukjent feil ved validering av fødselsnummer.'
     ),
-    WS_ERROR: definer(
-        FeilmeldingKode.WS_FEILET,
-        'Feil ved tilkobling mot ws-contextholder'
-    ),
+    WS_ERROR: definer(FeilmeldingKode.WS_FEILET, 'Feil ved tilkobling mot ws-contextholder'),
     HENT_AKTORID_FEILET: definer(
         FeilmeldingKode.HENT_AKTORID_FEILET,
         'Kunne ikke hente aktør-identifikator for bruker'
@@ -65,8 +55,10 @@ export const PredefiniertFeilmeldinger = {
     )
 };
 
-
-export type LeggTilFeilmelding = DataAction<FeilmeldingActionTypes.LEGG_TIL, PredefiniertFeilmelding>;
+export type LeggTilFeilmelding = DataAction<
+    FeilmeldingActionTypes.LEGG_TIL,
+    PredefiniertFeilmelding
+>;
 export type FjernFeilmelding = DataAction<FeilmeldingActionTypes.FJERN, FeilmeldingKode>;
 
 export type FeilmeldingerActions = LeggTilFeilmelding | FjernFeilmelding;

--- a/v2.1/src/redux/feilmeldinger/reducer.ts
+++ b/v2.1/src/redux/feilmeldinger/reducer.ts
@@ -5,7 +5,8 @@ import {
     FeilmeldingerActions,
     FeilmeldingKode,
     FjernFeilmelding,
-    LeggTilFeilmelding, PredefiniertFeilmelding
+    LeggTilFeilmelding,
+    PredefiniertFeilmelding
 } from './domain';
 import { Required } from '../utils';
 

--- a/v2.1/src/redux/fnr-initial-sync-saga.test.ts
+++ b/v2.1/src/redux/fnr-initial-sync-saga.test.ts
@@ -11,10 +11,10 @@ import initialSyncFnr from './fnr-initial-sync-saga';
 import { AKTIV_BRUKER_URL, ContextApiType, modiacontextholderUrl } from './api';
 import { FnrContextvalue, FnrDisplay } from '../domain';
 import { AktivBruker, AktivEnhet } from '../internal-domain';
-import {State} from "./index";
-import {RecursivePartial} from "./utils";
-import {PredefiniertFeilmeldinger} from "./feilmeldinger/domain";
-import {leggTilFeilmelding} from "./feilmeldinger/reducer";
+import { State } from './index';
+import { RecursivePartial } from './utils';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
+import { leggTilFeilmelding } from './feilmeldinger/reducer';
 
 function gittContextholder(
     context: Context,
@@ -125,7 +125,9 @@ describe('saga - root', () => {
 
         const dispatched = await run(initialSyncFnr, state, props);
 
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET)
+        );
         expect(dispatched[1]).toMatchObject({
             type: 'REDUX/UPDATESTATE',
             data: { fnr: { value: MaybeCls.nothing() } }
@@ -212,7 +214,9 @@ describe('saga - root', () => {
 
         const dispatched = await run(initialSyncFnr, state, props);
 
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.FNR_KONTROLL_SIFFER));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.FNR_KONTROLL_SIFFER)
+        );
         expect(dispatched[1]).toMatchObject({
             type: 'REDUX/UPDATESTATE',
             data: { fnr: { value: MaybeCls.just('12345678910') } }
@@ -230,7 +234,9 @@ describe('saga - root', () => {
 
         const dispatched = await run(initialSyncFnr, state, props);
 
-        expect(dispatched[0]).toMatchObject(leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET));
+        expect(dispatched[0]).toMatchObject(
+            leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET)
+        );
         expect(dispatched[1]).toMatchObject({
             type: 'REDUX/UPDATESTATE',
             data: { fnr: { value: MaybeCls.just(MOCK_FNR_1) } }

--- a/v2.1/src/redux/fnr-initial-sync-saga.ts
+++ b/v2.1/src/redux/fnr-initial-sync-saga.ts
@@ -4,19 +4,19 @@ import * as Api from './api';
 import {FetchResponse, hasError} from './api';
 import {AktivBruker} from '../internal-domain';
 import {lagFnrFeilmelding} from '../utils/fnr-utils';
-import {RESET_VALUE, spawnConditionally} from './utils';
+import {getContextvalueValue, RESET_VALUE, spawnConditionally} from './utils';
 import {FnrContextvalue} from '../domain';
 import {updateFnrValue} from './fnr-update-sagas';
 import {leggTilFeilmelding} from './feilmeldinger/reducer';
 import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
 
 export default function* initialSyncFnr(props: FnrContextvalue) {
-    if (props.initialValue === RESET_VALUE) {
+    if (getContextvalueValue(props) === RESET_VALUE) {
         yield call(Api.nullstillAktivBruker);
     }
 
     const response: FetchResponse<AktivBruker> = yield call(Api.hentAktivBruker);
-    const onsketFnr = MaybeCls.of(props.initialValue)
+    const onsketFnr = MaybeCls.of(getContextvalueValue(props))
         .map((fnr) => (fnr === RESET_VALUE ? '' : fnr))
         .map((fnr) => fnr.trim())
         .filter((fnr) => fnr.length > 0);

--- a/v2.1/src/redux/fnr-initial-sync-saga.ts
+++ b/v2.1/src/redux/fnr-initial-sync-saga.ts
@@ -1,14 +1,14 @@
-import {call, fork, put} from 'redux-saga/effects';
-import {MaybeCls} from '@nutgaard/maybe-ts';
+import { call, fork, put } from 'redux-saga/effects';
+import { MaybeCls } from '@nutgaard/maybe-ts';
 import * as Api from './api';
-import {FetchResponse, hasError} from './api';
-import {AktivBruker} from '../internal-domain';
-import {lagFnrFeilmelding} from '../utils/fnr-utils';
-import {getContextvalueValue, RESET_VALUE, spawnConditionally} from './utils';
-import {FnrContextvalue} from '../domain';
-import {updateFnrValue} from './fnr-update-sagas';
-import {leggTilFeilmelding} from './feilmeldinger/reducer';
-import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
+import { FetchResponse, hasError } from './api';
+import { AktivBruker } from '../internal-domain';
+import { lagFnrFeilmelding } from '../utils/fnr-utils';
+import { getContextvalueValue, RESET_VALUE, spawnConditionally } from './utils';
+import { FnrContextvalue } from '../domain';
+import { updateFnrValue } from './fnr-update-sagas';
+import { leggTilFeilmelding } from './feilmeldinger/reducer';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
 
 export default function* initialSyncFnr(props: FnrContextvalue) {
     if (getContextvalueValue(props) === RESET_VALUE) {
@@ -28,9 +28,7 @@ export default function* initialSyncFnr(props: FnrContextvalue) {
         .filter((fnr) => fnr.length > 0);
 
     if (hasError(response)) {
-        yield put(
-            leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET)
-        );
+        yield put(leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_BRUKER_CONTEXT_FEILET));
     }
 
     if (feilFnr.isJust()) {

--- a/v2.1/src/redux/fnr-update-sagas.ts
+++ b/v2.1/src/redux/fnr-update-sagas.ts
@@ -8,7 +8,7 @@ import * as Api from './api';
 import { FetchResponse, hasError } from './api';
 import { FnrReset, FnrSubmit, ReduxActionTypes, SagaActionTypes } from './actions';
 import { leggTilFeilmelding } from './feilmeldinger/reducer';
-import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
 
 export function* hentAktorId() {
     const state: InitializedState = yield selectFromInitializedState((state) => state);
@@ -26,9 +26,7 @@ export function* hentAktorId() {
         if (feilFnr.isNothing()) {
             const response: FetchResponse<AktorIdResponse> = yield call(Api.hentAktorId, fnr);
             if (hasError(response)) {
-                yield put(
-                    leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_AKTORID_FEILET)
-                );
+                yield put(leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_AKTORID_FEILET));
             } else {
                 yield put({ type: ReduxActionTypes.AKTORIDDATA, data: response.data });
             }

--- a/v2.1/src/redux/init-sagas.ts
+++ b/v2.1/src/redux/init-sagas.ts
@@ -11,7 +11,7 @@ import {updateFnr} from './fnr-update-sagas';
 import {updateEnhet} from './enhet-update-sagas';
 import {wsListener} from './wsSaga';
 import {InitializedState} from './reducer';
-import {RESET_VALUE} from './utils';
+import {getContextvalueValue, RESET_VALUE} from './utils';
 import log from './../utils/logging';
 import {leggTilFeilmelding} from './feilmeldinger/reducer';
 import {PredefiniertFeilmeldinger} from './feilmeldinger/domain';
@@ -21,7 +21,7 @@ function* initializeStore(props: ApplicationProps, saksbehandler: MaybeCls<Saksb
         .map((config) => {
             return {
                 enabled: true,
-                value: MaybeCls.of(config.initialValue).filter((fnr) => fnr !== RESET_VALUE),
+                value: MaybeCls.of(getContextvalueValue(config)).filter((fnr) => fnr !== RESET_VALUE),
                 wsRequestedValue: MaybeCls.nothing<string>(),
                 onChange: config.onChange,
                 display: FnrDisplay.SOKEFELT,
@@ -36,7 +36,7 @@ function* initializeStore(props: ApplicationProps, saksbehandler: MaybeCls<Saksb
         .map((config) => {
             return {
                 enabled: true,
-                value: MaybeCls.of(config.initialValue).filter((enhet) => enhet !== RESET_VALUE),
+                value: MaybeCls.of(getContextvalueValue(config)).filter((enhet) => enhet !== RESET_VALUE),
                 wsRequestedValue: MaybeCls.nothing<string>(),
                 onChange: config.onChange,
                 display: config.display,

--- a/v2.1/src/redux/utils.ts
+++ b/v2.1/src/redux/utils.ts
@@ -2,6 +2,7 @@ import { select, spawn } from 'redux-saga/effects';
 import { InitializedState, isInitialized } from './reducer';
 import { State } from './index';
 import { Action } from 'redux';
+import {Contextvalue, ControlledContextvalue} from "../domain";
 
 export const RESET_VALUE = '\u0000';
 
@@ -22,6 +23,20 @@ export function* selectFromInitializedState<T, Fn extends (state: InitializedSta
         return selector(state);
     }
     throw new Error('Could not get data from state since it is not initialized yet.');
+}
+
+export function isContextvalueControlled<T>(contextValue: Contextvalue<T>): contextValue is ControlledContextvalue<T> {
+    return (contextValue as any).value !== undefined;
+}
+
+export function getContextvalueValue(contextValue?: Contextvalue<any>): string | null {
+    if (contextValue === undefined) {
+        return null;
+    } else if (isContextvalueControlled(contextValue)) {
+        return contextValue.value;
+    } else {
+        return contextValue.initialValue;
+    }
 }
 
 export interface DataAction<TYPE, DATA> extends Action<TYPE> {

--- a/v2.1/src/redux/utils.ts
+++ b/v2.1/src/redux/utils.ts
@@ -2,7 +2,7 @@ import { select, spawn } from 'redux-saga/effects';
 import { InitializedState, isInitialized } from './reducer';
 import { State } from './index';
 import { Action } from 'redux';
-import {Contextvalue, ControlledContextvalue} from "../domain";
+import { Contextvalue, ControlledContextvalue } from '../domain';
 
 export const RESET_VALUE = '\u0000';
 
@@ -25,9 +25,11 @@ export function* selectFromInitializedState<T, Fn extends (state: InitializedSta
     throw new Error('Could not get data from state since it is not initialized yet.');
 }
 
-export function isContextvalueControlled<T>(contextValue?: Contextvalue<T>): contextValue is ControlledContextvalue<T> {
+export function isContextvalueControlled<T>(
+    contextValue?: Contextvalue<T>
+): contextValue is ControlledContextvalue<T> {
     if (contextValue === undefined) {
-        return false
+        return false;
     }
     return (contextValue as any).value !== undefined;
 }

--- a/v2.1/src/redux/utils.ts
+++ b/v2.1/src/redux/utils.ts
@@ -25,7 +25,10 @@ export function* selectFromInitializedState<T, Fn extends (state: InitializedSta
     throw new Error('Could not get data from state since it is not initialized yet.');
 }
 
-export function isContextvalueControlled<T>(contextValue: Contextvalue<T>): contextValue is ControlledContextvalue<T> {
+export function isContextvalueControlled<T>(contextValue?: Contextvalue<T>): contextValue is ControlledContextvalue<T> {
+    if (contextValue === undefined) {
+        return false
+    }
     return (contextValue as any).value !== undefined;
 }
 

--- a/v2.1/src/redux/wsSaga.ts
+++ b/v2.1/src/redux/wsSaga.ts
@@ -9,7 +9,7 @@ import { selectFromInitializedState } from './utils';
 import { updateWSRequestedEnhet } from './enhet-update-sagas';
 import { updateWSRequestedFnr } from './fnr-update-sagas';
 import { leggTilFeilmelding } from './feilmeldinger/reducer';
-import { PredefiniertFeilmeldinger} from './feilmeldinger/domain';
+import { PredefiniertFeilmeldinger } from './feilmeldinger/domain';
 
 enum WsChangeEventType {
     MESSAGE,

--- a/v2.1/src/utils/fnr-utils.ts
+++ b/v2.1/src/utils/fnr-utils.ts
@@ -1,5 +1,5 @@
-import {MaybeCls} from '@nutgaard/maybe-ts';
-import {PredefiniertFeilmelding, PredefiniertFeilmeldinger} from "../redux/feilmeldinger/domain";
+import { MaybeCls } from '@nutgaard/maybe-ts';
+import { PredefiniertFeilmelding, PredefiniertFeilmeldinger } from '../redux/feilmeldinger/domain';
 
 const kontrollRekke1 = [3, 7, 6, 1, 8, 9, 4, 5, 2];
 const kontrollRekke2 = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2];


### PR DESCRIPTION
De fleste applikasjonen vil ikke trenge dette, men er nyttig for å gjøre overgangen fra V2 til V2.1 enklere. 

Hvordan det fungerer;
Om `value` sendes inn så settes dekoratøren i _controlled_ modus, dvs om `value` endres i etterkant så vil dekoratøren simulere (via redux-actions) bruker-interaksjonen, e.g kalle `FNRSUBMIT`, `FNRRESET` og `ENHETCHANGED`. Dette er de samme redux-action-typene som brukes ved direkte endringer via søkefeltet, og vil sådan hoppe inn i samme saga-flyt.

Om `initialValue` sendes inn så settes dekoratøren i _uncontrolled_ modus, og den vil da fungere som tidligere. E.g endringer i props vil ikke ha noen effekt på dekoratøren.

Hvorfor:
Modiapersonoversikt bruker i dag V2 som er en controlled-component. E.g fra start-bilde etc så endrer man bare på url i react-router, så fanger appen opp hva den må gjøre uten at hele appen må lastet på nytt. For å beholde denne funksjonalitet så trenger man _controlled_-modus i V2.1 også.