### PR TITLE
Dialogmøte to dialogmøteoversikt

### DIFF
--- a/js/menyConfig.js
+++ b/js/menyConfig.js
@@ -112,7 +112,7 @@ export const funksjonsomradeLenker = (fnr, enhet) => [
                 url: `https://syfooversikt${naisDomain}minoversikt`,
             },
             {
-                tittel: 'Dialogmøte',
+                tittel: 'Dialogmøteoversikt',
                 url: `https://syfomoteoversikt${naisDomain}`,
             },
             {

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -141,7 +141,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                         <ul className="dekorator__menyliste">
                             <Lenke href={`https://syfooversikt${naisDomain}/enhet`}>Enhetens oversikt</Lenke>
                             <Lenke href={`https://syfooversikt${naisDomain}/minoversikt`}>Min oversikt</Lenke>
-                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøte</Lenke>
+                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøteoversikt</Lenke>
                             <Lenke href={`https://finnfastlege${naisDomain}/fastlege/`}>Finn fastlege</Lenke>
                             <Lenke href={appDomain(`/sykefravaer/${fnr ? fnr : ''}`)}>
                                 Sykmeldt enkeltperson

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -140,7 +140,7 @@ function Lenker() {
                         <ul className="dekorator__menyliste">
                             <Lenke href={`https://syfooversikt${naisDomain}/enhet`}>Enhetens oversikt</Lenke>
                             <Lenke href={`https://syfooversikt${naisDomain}/minoversikt`}>Min oversikt</Lenke>
-                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøte</Lenke>
+                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøteoversikt</Lenke>
                             <Lenke href={`https://finnfastlege${naisDomain}/fastlege/`}>Finn fastlege</Lenke>
                             <Lenke href={`https://syfomodiaperson${naisDomain}/sykefravaer/${fnr ? fnr : ''}`}>
                                 Sykmeldt enkeltperson


### PR DESCRIPTION
Veiledere forstår ikke forskjellen på dialogmøter i menyen og dialogmøter på sykmeldt enkeltperson. Flere tror de må gjennom dialogmøter i menyen for å kunne kalle inn til møte. 

Det er ønskelig å endre fra Dialogmøte til Dialogmøteoversikt