### PR TITLE
[KAIZEN-0] hente aktorId fra pdl

### DIFF
--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback} from 'react';
-import {MaybeCls} from '@nutgaard/maybe-ts';
 import {finnMiljoStreng, finnNaisMiljoStreng} from '../utils/url-utils';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 import {WrappedState} from "../hooks/use-wrapped-state";
@@ -72,12 +71,8 @@ function lagHotkeys(fnr: string, aktorId: string): Array<Hotkey> {
 function Lenker({apen}: { apen: WrappedState<boolean> }) {
     const fnr = useFnrContextvalueState().withDefault('');
     const enhet = useEnhetContextvalueState().withDefault('');
-    const aktorId = useInitializedState((state) => state.data.aktorId)
-        .flatMap((resp) => MaybeCls.of(resp[fnr]))
-        .flatMap((resp) => MaybeCls.of(resp.identer))
-        .filter((identer) => identer.some((ident) => ident.gjeldende))
-        .map((identer) => identer.find((ident) => ident.gjeldende)!)
-        .map(({ident}) => ident)
+    const aktorId: string = useInitializedState((state) => state.data.aktorId)
+        .map((resp) => resp.aktorId)
         .withDefault('');
 
     const hotkeys = useCallback(lagHotkeys, [fnr, aktorId])(fnr, aktorId);

--- a/v2.1/src/internal-domain.ts
+++ b/v2.1/src/internal-domain.ts
@@ -33,14 +33,8 @@ export interface Toggles {
 }
 
 export interface AktorIdResponse {
-    [fnr: string]: {
-        feilmelding: null | string;
-        identer: null | Array<{
-            gjeldende: boolean;
-            ident: string;
-            identgruppe: string;
-        }>;
-    };
+    fnr: string;
+    aktorId: string;
 }
 
 export interface AktivEnhet {

--- a/v2.1/src/mock/index.ts
+++ b/v2.1/src/mock/index.ts
@@ -6,7 +6,6 @@ import FetchMock, {
 } from 'yet-another-fetch-mock';
 import { AktorIdResponse, Saksbehandler } from '../internal-domain';
 import { setupWsControlAndMock } from './context-mock';
-import { finnMiljoStreng } from '../utils/url-utils';
 import failureConfig from './mock-error-config';
 
 console.log('============================');
@@ -47,13 +46,11 @@ mock.get(
     )
 );
 
-mock.get(`https://app${finnMiljoStreng()}.adeo.no/aktoerregister/api/v1/identer`, (args) => {
-    const fnr = (args.init!.headers! as Record<string, string>)['Nav-Personidenter'];
+mock.get('/modiacontextholder/api/aktor/:fnr', (args) => {
+    const fnr = args.pathParams.fnr;
     const data: AktorIdResponse = {
-        [fnr]: {
-            feilmelding: null,
-            identer: [{ gjeldende: true, ident: `000${fnr}000`, identgruppe: 'AktoerId' }]
-        }
+        fnr,
+        aktorId: `000${fnr}000`
     };
 
     return new Promise((resolve, reject) => {

--- a/v2.1/src/redux/api.ts
+++ b/v2.1/src/redux/api.ts
@@ -1,6 +1,6 @@
 import {MaybeCls} from "@nutgaard/maybe-ts";
 import { lagFnrFeilmelding } from '../utils/fnr-utils';
-import { finnMiljoStreng, hentMiljoFraUrl, randomGuid } from '../utils/url-utils';
+import { finnMiljoStreng, hentMiljoFraUrl } from '../utils/url-utils';
 import { AktivBruker, AktivEnhet, AktorIdResponse, Saksbehandler } from '../internal-domain';
 import failureConfig from './../mock/mock-error-config';
 
@@ -29,7 +29,7 @@ export const modiacontextholderUrl = lagModiacontextholderUrl();
 export const AKTIV_ENHET_URL = `${modiacontextholderUrl}/context/aktivenhet`;
 export const AKTIV_BRUKER_URL = `${modiacontextholderUrl}/context/aktivbruker`;
 export const SAKSBEHANDLER_URL = `${modiacontextholderUrl}/decorator`;
-export const AKTORID_URL = `https://app${finnMiljoStreng()}.adeo.no/aktoerregister/api/v1/identer?identgruppe=AktoerId`;
+export const AKTORID_URL = (fnr: string) => `${modiacontextholderUrl}/aktor/${fnr}`;
 
 export type ResponseError = { data: undefined; error: string };
 export type ResponseOk<T> = { data: T; error: undefined };
@@ -79,16 +79,7 @@ export function hentAktorId(fnr: string): Promise<FetchResponse<AktorIdResponse>
         return Promise.reject('Ugyldig fødselsnummer, kan ikke hente aktørId');
     }
 
-    const request: RequestInit = {
-        credentials: 'include',
-        headers: {
-            'Nav-Consumer-Id': 'internarbeidsflatedecorator',
-            'Nav-Call-Id': randomGuid(),
-            'Nav-Personidenter': fnr
-        }
-    };
-
-    return getJson<AktorIdResponse>(AKTORID_URL, request);
+    return getJson<AktorIdResponse>(AKTORID_URL(fnr));
 }
 
 export function logError(message: string, extra: { [key: string ]: string }) {

--- a/v2.1/src/redux/fnr-update-sagas.ts
+++ b/v2.1/src/redux/fnr-update-sagas.ts
@@ -18,7 +18,8 @@ export function* hentAktorId() {
             throw new Error(`'state.fnr' was NOTHING while expecting JUST`);
         });
 
-        if (state.data.aktorId.filter((data) => data[fnr] !== undefined).isJust()) {
+        const hasLoadedAktorIdForFnr = state.data.aktorId.filter((data) => data.fnr === fnr).isJust();
+        if (hasLoadedAktorIdForFnr) {
             return;
         }
 

--- a/v2.1/src/utils/url-utils.ts
+++ b/v2.1/src/utils/url-utils.ts
@@ -81,12 +81,3 @@ export function finnNaisMiljoStreng(envNamespace: boolean = false) {
     }
     return `${prefix}.nais.preprod.local`;
 }
-
-export function randomGuid() {
-    let idx = 0;
-    const c = window.crypto || window.msCrypto;
-    const rnd = Array.from(c.getRandomValues(new Uint8Array(32))).map((value) =>
-        (value & 15).toString(16)
-    );
-    return '00000000-0000-0000-0000-000000000000'.replace(/0/g, () => rnd[idx++]);
-}


### PR DESCRIPTION
man planlegger sanering av aktorregister, og vi må da begynne å hente
aktorid fra pdl. For å oppnå dette er det satt opp ett endepunkt i
modiacontextholder som håndterer kall og caching mot pdl