### PR TITLE
[KAIZEN-0] legge til muligheten for url-overstyring

### DIFF
--- a/v2.1/README.md
+++ b/v2.1/README.md
@@ -48,6 +48,8 @@ export interface DecoratorProps {
     enhet?: EnhetContextvalue;      // Konfigurasjon av enhet-kontekst
     toggles?: TogglesConfig;        // Konfigurasjon av hvilke elementer som skal vises i dekoratøren
     markup?: Markup;                // Ekstra innhold i dekoratøren, kan brukes om man trenger å legge en knapp innenfor dekoratøren
+    
+    useProxy?: boolean;             // Manuell overstyring av urlene til BFFs. Gjør alle kall til relativt path, og trenger derfor proxy oppsett. Default: false 
     accessToken?: string;           // Manuell innsending av JWT, settes som Authorization-header. Om null sendes cookies vha credentials: 'include' 
 }
 

--- a/v2.1/src/domain.ts
+++ b/v2.1/src/domain.ts
@@ -40,5 +40,6 @@ export interface ApplicationProps {
     enhet?: EnhetContextvalue;
     toggles?: TogglesConfig;
     markup?: Markup;
+    useProxy?: boolean;
     accessToken?: string;
 }

--- a/v2.1/src/redux/enhet-initial-sync-saga.test.ts
+++ b/v2.1/src/redux/enhet-initial-sync-saga.test.ts
@@ -1,12 +1,8 @@
 import { runSaga, Saga } from 'redux-saga';
-import FetchMock, {
-    MatcherUrl,
-    MatcherUtils,
-    SpyMiddleware
-} from 'yet-another-fetch-mock';
+import FetchMock, { MatcherUrl, MatcherUtils, SpyMiddleware } from 'yet-another-fetch-mock';
 import { MaybeCls } from '@nutgaard/maybe-ts';
 import initialSyncEnhet from './enhet-initial-sync-saga';
-import { AKTIV_BRUKER_URL, AKTIV_ENHET_URL, ContextApiType, modiacontextholderUrl } from './api';
+import { urls, ContextApiType } from './api';
 import { AktivBruker, AktivEnhet, AktorIdResponse, Enhet, Saksbehandler } from '../internal-domain';
 import { EnhetContextvalue, EnhetDisplay } from '../domain';
 import { RecursivePartial } from './utils';
@@ -55,14 +51,22 @@ function gittOnsketEnhet(enhet: string | null): EnhetContextvalue {
 function gittContextholder(context: Context, aktiveContext: ContextholderValue) {
     context.contextholder.aktivBruker = aktiveContext.aktivBruker;
     context.contextholder.aktivEnhet = aktiveContext.aktivEnhet;
-    context.mock.get('/modiacontextholder/api/context/aktivenhet', (req, res, ctx) => res(ctx.json({
-        aktivEnhet: aktiveContext.aktivEnhet,
-        aktivBruker: null
-    })));
-    context.mock.get('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => res(ctx.json({
-        aktivEnhet: null,
-        aktivBruker: aktiveContext.aktivBruker
-    })));
+    context.mock.get('/modiacontextholder/api/context/aktivenhet', (req, res, ctx) =>
+        res(
+            ctx.json({
+                aktivEnhet: aktiveContext.aktivEnhet,
+                aktivBruker: null
+            })
+        )
+    );
+    context.mock.get('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
+        res(
+            ctx.json({
+                aktivEnhet: null,
+                aktivBruker: aktiveContext.aktivBruker
+            })
+        )
+    );
     context.mock.delete('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => {
         context.contextholder.aktivBruker = null;
         return res(ctx.status(200));
@@ -127,8 +131,8 @@ describe('saga - root', () => {
 
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(spy.called(MatcherUtils.del(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.del(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe(null);
     });
 
@@ -146,8 +150,8 @@ describe('saga - root', () => {
 
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(spy.called(MatcherUtils.del(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.del(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe(null);
     });
 
@@ -169,10 +173,8 @@ describe('saga - root', () => {
 
         expect(props.onChange).toBeCalledWith('1234');
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe('1234');
     });
 
@@ -194,10 +196,8 @@ describe('saga - root', () => {
 
         expect(props.onChange).toBeCalledWith('1235');
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeFalsy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeFalsy();
         expect(context.contextholder.aktivEnhet).toBe('1235');
     });
 
@@ -214,8 +214,8 @@ describe('saga - root', () => {
         );
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(spy.called(MatcherUtils.del(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.del(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe(null);
     });
 
@@ -232,8 +232,8 @@ describe('saga - root', () => {
         );
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(spy.called(MatcherUtils.del(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.del(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe(null);
     });
 
@@ -254,10 +254,8 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe('1235');
     });
 
@@ -278,10 +276,8 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeFalsy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeFalsy();
         expect(context.contextholder.aktivEnhet).toBe('1234');
     });
 
@@ -302,10 +298,8 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_ENHET_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivEnhetUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivEnhet).toBe('1235');
     });
 });

--- a/v2.1/src/redux/fnr-initial-sync-saga.test.ts
+++ b/v2.1/src/redux/fnr-initial-sync-saga.test.ts
@@ -1,12 +1,8 @@
 import { runSaga, Saga } from 'redux-saga';
-import FetchMock, {
-    MatcherUrl,
-    MatcherUtils,
-    SpyMiddleware
-} from 'yet-another-fetch-mock';
+import FetchMock, { MatcherUrl, MatcherUtils, SpyMiddleware } from 'yet-another-fetch-mock';
 import { MaybeCls } from '@nutgaard/maybe-ts';
 import initialSyncFnr from './fnr-initial-sync-saga';
-import { AKTIV_BRUKER_URL, ContextApiType, modiacontextholderUrl } from './api';
+import { urls, ContextApiType } from './api';
 import { FnrContextvalue, FnrDisplay } from '../domain';
 import { AktivBruker, AktivEnhet } from '../internal-domain';
 import { State } from './index';
@@ -22,24 +18,30 @@ function gittContextholder(
     context.contextholder.aktivBruker = aktiveContext.aktivBruker;
     context.contextholder.aktivEnhet = aktiveContext.aktivEnhet;
     if (error) {
-        context.mock.get(
-            '/modiacontextholder/api/context/aktivenhet',
-            (_, res, ctx) => res(ctx.status(500))
+        context.mock.get('/modiacontextholder/api/context/aktivenhet', (_, res, ctx) =>
+            res(ctx.status(500))
         );
-        context.mock.get(
-            '/modiacontextholder/api/context/aktivbruker',
-            (_, res, ctx) => res(ctx.status(500))
+        context.mock.get('/modiacontextholder/api/context/aktivbruker', (_, res, ctx) =>
+            res(ctx.status(500))
         );
         context.mock.post('/modiacontextholder/api/context', (_, res, ctx) => res(ctx.status(500)));
     } else {
-        context.mock.get('/modiacontextholder/api/context/aktivenhet', (_, res, ctx) => res(ctx.json({
-            aktivEnhet: aktiveContext.aktivEnhet,
-            aktivBruker: null
-        })));
-        context.mock.get('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => res(ctx.json({
-            aktivEnhet: null,
-            aktivBruker: aktiveContext.aktivBruker
-        })));
+        context.mock.get('/modiacontextholder/api/context/aktivenhet', (_, res, ctx) =>
+            res(
+                ctx.json({
+                    aktivEnhet: aktiveContext.aktivEnhet,
+                    aktivBruker: null
+                })
+            )
+        );
+        context.mock.get('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
+            res(
+                ctx.json({
+                    aktivEnhet: null,
+                    aktivBruker: aktiveContext.aktivBruker
+                })
+            )
+        );
         context.mock.post('/modiacontextholder/api/context', ({ body }, res, ctx) => {
             const { verdi, eventType } = body;
             if (eventType === ContextApiType.NY_AKTIV_BRUKER) {
@@ -133,7 +135,7 @@ describe('saga - root', () => {
 
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
     });
 
     it('onsketFnr: null, aktivBruker: null => stateFnr: Nothing', async () => {
@@ -149,7 +151,7 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
     });
 
     it(`onsketFnr: null, aktivBruker: ${MOCK_FNR_1} => stateFnr: Just(${MOCK_FNR_1})`, async () => {
@@ -165,7 +167,7 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
     });
 
     it(`onsketFnr: ${MOCK_FNR_2}, aktivBruker: ${MOCK_FNR_1} => stateFnr: Just(${MOCK_FNR_2})`, async () => {
@@ -181,10 +183,8 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivBruker).toBe(MOCK_FNR_2);
     });
 
@@ -201,7 +201,7 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivBruker).toBe(MOCK_FNR_1);
     });
 
@@ -221,7 +221,7 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(0);
         expect(spy.size()).toBe(1);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivBruker).toBe(MOCK_FNR_1);
     });
 
@@ -241,10 +241,8 @@ describe('saga - root', () => {
         });
         expect(props.onChange).toBeCalledTimes(1);
         expect(spy.size()).toBe(2);
-        expect(spy.called(MatcherUtils.get(AKTIV_BRUKER_URL as MatcherUrl))).toBeTruthy();
-        expect(
-            spy.called(MatcherUtils.post(`${modiacontextholderUrl}/context` as MatcherUrl))
-        ).toBeTruthy();
+        expect(spy.called(MatcherUtils.get(urls.aktivBrukerUrl as MatcherUrl))).toBeTruthy();
+        expect(spy.called(MatcherUtils.post(urls.contextUrl as MatcherUrl))).toBeTruthy();
         expect(context.contextholder.aktivBruker).toBe(MOCK_FNR_1);
     });
 });

--- a/v2.1/src/redux/init-sagas.ts
+++ b/v2.1/src/redux/init-sagas.ts
@@ -72,7 +72,11 @@ function* initializeStore(props: ApplicationProps, saksbehandler: MaybeCls<Saksb
 }
 
 function* initDekoratorData(props: ApplicationProps) {
-    yield call(Api.setAccessToken, props.accessToken);
+    Api.setAccessToken(props.accessToken);
+    if (props.useProxy) {
+        Api.setUseProxy();
+    }
+
     const response: FetchResponse<Saksbehandler> = yield call(Api.hentSaksbehandlerData);
     if (hasError(response)) {
         yield put(leggTilFeilmelding(PredefiniertFeilmeldinger.HENT_SAKSBEHANDLER_DATA_FEILET));


### PR DESCRIPTION
ved å bruke `useProxy`  vil alle http-kall bli sendt via relativ url, og konsumentene kan så gjøre evt token-exchange før proxying videre til modiacontextholder et.al