### PR TITLE
Legger til støtte for preprod-urlen dev.adeo.no.

### DIFF
--- a/v2.1/src/utils/url-utils.test.ts
+++ b/v2.1/src/utils/url-utils.test.ts
@@ -66,6 +66,16 @@ describe('url-utils', () => {
             });
         });
 
+        it('skal identifisere dev-adeo urler som dev. Bruk dekorator i q0', () => {
+            withLocation('https://navn.dev.adeo.no/contextpath/', () => {
+                expect(hentMiljoFraUrl()).toEqual({
+                    environment: 'q0',
+                    isNaisUrl: true,
+                    envclass: 'q'
+                });
+            });
+        });
+
         it('skal identifisere nais-prod urler', () => {
             withLocation('https://navn-q.nais.adeo.no/contextpath', () => {
                 expect(hentMiljoFraUrl()).toEqual({

--- a/v2.1/src/utils/url-utils.ts
+++ b/v2.1/src/utils/url-utils.ts
@@ -41,6 +41,10 @@ const urlRules: Array<UrlRule> = [
         ifMatch: (match) => ({ environment: 'q0', isNaisUrl: true, envclass: 'q' })
     },
     {
+        regExp: /\.dev\.adeo\.no/,
+        ifMatch: (match) => ({ environment: 'q0', isNaisUrl: true, envclass: 'q' })
+    },
+    {
         regExp: /\.nais\.adeo\.no/,
         ifMatch: (match) => ({ environment: 'p', isNaisUrl: true, envclass: 'p' })
     },


### PR DESCRIPTION
Legger til støtte for preprod-urlen dev.adeo.no.
Denne url-en er anbefalt i nais-docen:
https://doc.nais.io/clusters/on-premises#dev-fss
(Sosialhjelp modia bruker denne)

NB: ønsker å bruke samme contextholder som blir brukt av andre modia-apper, derfor har jeg satt environment:q0. Ønsker diskusjon på dette.