### PR TITLE
La apper i dev.adeo.no gå mot contextholder i dev.adeo.no

### DIFF
--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -11,6 +11,7 @@ spec:
   port: 80
   ingresses:
   - https://internarbeidsflatedecorator-{{ namespace }}.nais.preprod.local
+  - https://internarbeidsflatedecorator-{{ namespace }}.dev.adeo.no
   - https://app-{{ namespace }}.adeo.no/internarbeidsflatedecorator
   - https://modapp-{{ namespace }}.adeo.no/internarbeidsflatedecorator
   liveness:

--- a/v2.1/src/redux/api.ts
+++ b/v2.1/src/redux/api.ts
@@ -24,6 +24,8 @@ export function lagModiacontextholderUrl(useProxy: boolean = false): string {
         return '/modiacontextholder/api';
     } else if (urlEnv.isNaisUrl && urlEnv.envclass === 'q') {
         return `https://modiacontextholder-${urlEnv.environment}.nais.preprod.local/modiacontextholder/api`;
+    } else if (urlEnv.isNaisUrl && urlEnv.envclass === 'dev') {
+        return `https://modiacontextholder-${urlEnv.environment}.dev.adeo.no/modiacontextholder/api`;
     } else if (urlEnv.isNaisUrl && urlEnv.envclass === 'p') {
         return `https://modiacontextholder.nais.adeo.no/modiacontextholder/api`;
     } else if (!urlEnv.isNaisUrl && urlEnv.envclass !== 'p') {

--- a/v2.1/src/utils/url-utils.test.ts
+++ b/v2.1/src/utils/url-utils.test.ts
@@ -71,7 +71,7 @@ describe('url-utils', () => {
                 expect(hentMiljoFraUrl()).toEqual({
                     environment: 'q0',
                     isNaisUrl: true,
-                    envclass: 'q'
+                    envclass: 'dev'
                 });
             });
         });

--- a/v2.1/src/utils/url-utils.ts
+++ b/v2.1/src/utils/url-utils.ts
@@ -42,7 +42,7 @@ const urlRules: Array<UrlRule> = [
     },
     {
         regExp: /\.dev\.adeo\.no/,
-        ifMatch: (match) => ({ environment: 'q0', isNaisUrl: true, envclass: 'q' })
+        ifMatch: (match) => ({ environment: 'q0', isNaisUrl: true, envclass: 'dev' })
     },
     {
         regExp: /\.nais\.adeo\.no/,


### PR DESCRIPTION
* Introduserer ny envclass:dev som brukes når en app kjører på dev.adeo.no
* Lar dekoratøren kjøre på dev.adeo.no (hvorfor har den ingen contextpath, @nutgaard ?)