### PR TITLE
dev.adeo.no-url for veilederflatehendelser, om host er dev.adeo.no.

### DIFF
--- a/v2.1/src/redux/api.test.ts
+++ b/v2.1/src/redux/api.test.ts
@@ -1,4 +1,4 @@
-import { lagModiacontextholderUrl } from './api';
+import { getVeilederflatehendelserUrl, lagModiacontextholderUrl } from './api';
 import { withLocation } from '../utils/test.utils';
 
 describe('api', () => {
@@ -53,6 +53,62 @@ describe('api', () => {
                     'https://app.adeo.no/modiacontextholder/api'
                 );
             });
+        });
+    });
+});
+
+describe('getVeilederflatehendelserUrl', () => {
+    it('skal ha riktig wss-url i dev.adeo.no', () => {
+        withLocation('https://navn.dev.adeo.no/contextpath/', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser-q0.dev.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+    });
+
+    it('skal ha riktig nais-url ved kjøring på nais-preprod', () => {
+        withLocation('https://navn-q6.nais.preprod.local/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser-q6.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+
+        withLocation('https://navn.nais.preprod.local/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser-q0.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+    });
+
+    it('skal ha riktig nais-url ved kjøring på nais-prod', () => {
+        withLocation('https://navn-q.nais.adeo.no/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+    });
+
+    it('skal ha riktig url ved kjøring på app-XX.adeo.no', () => {
+        withLocation('https://app-q6.adeo.no/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser-q6.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+    });
+
+    it('skal ha riktig url ved kjøring på app.adeo.no', () => {
+        withLocation('https://app.adeo.no/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser.adeo.no/modiaeventdistribution/ws/navident'
+            );
+        });
+    });
+
+    it('skal ha fallback til prod om alt feiler', () => {
+        withLocation('https://vg.no/contextpath', () => {
+            expect(getVeilederflatehendelserUrl('navident')).toBe(
+                'wss://veilederflatehendelser.adeo.no/modiaeventdistribution/ws/navident'
+            );
         });
     });
 });

--- a/v2.1/src/redux/api.ts
+++ b/v2.1/src/redux/api.ts
@@ -167,10 +167,12 @@ export function getWebSocketUrl(maybeSaksbehandler: MaybeCls<Saksbehandler>): st
     } else {
         return maybeSaksbehandler
             .map((saksbehandler) => saksbehandler.ident)
-            .map(
-                (ident) =>
-                    `wss://veilederflatehendelser${finnMiljoStreng()}.adeo.no/modiaeventdistribution/ws/${ident}`
-            )
+            .map((ident) => getVeilederflatehendelserUrl(ident))
             .withDefault(null);
     }
+}
+
+export function getVeilederflatehendelserUrl(ident: string) {
+    let subdomain = hentMiljoFraUrl().envclass == 'dev' ? '.dev' : '';
+    return `wss://veilederflatehendelser${finnMiljoStreng()}${subdomain}.adeo.no/modiaeventdistribution/ws/${ident}`;
 }

--- a/v2.1/src/redux/api.ts
+++ b/v2.1/src/redux/api.ts
@@ -173,6 +173,6 @@ export function getWebSocketUrl(maybeSaksbehandler: MaybeCls<Saksbehandler>): st
 }
 
 export function getVeilederflatehendelserUrl(ident: string) {
-    let subdomain = hentMiljoFraUrl().envclass == 'dev' ? '.dev' : '';
+    let subdomain = hentMiljoFraUrl().envclass === 'dev' ? '.dev' : '';
     return `wss://veilederflatehendelser${finnMiljoStreng()}${subdomain}.adeo.no/modiaeventdistribution/ws/${ident}`;
 }


### PR DESCRIPTION
Ta i bruk dev.adeo.no-url for veilederflatehendelser, dersom internarbeidsflatedecorator kjører på dev.adeo.no.

Laget tester som passer på at veilederflatehendelser-url er som den har vært for alle andre miljøer, men inkluderer .dev dersom man kjører på dev.adeo.no.

NB. jeg har ikke testet dette annet enn via enhetstester.