### PR TITLE
[PROD] Lenke til SF

### DIFF
--- a/js/menyConfig.js
+++ b/js/menyConfig.js
@@ -240,6 +240,13 @@ export function inst2() {
         url: getINST2NaisUrl(),
     };
 }
+export function salesforce() {
+    const url = finnMiljoStreng() === '' ? 'https://navdialog.lightning.force.com' : 'https://navdialog--preprod.lightning.force.com';
+    return {
+        tittel: 'Salesforce',
+        url,
+    };
+}
 
 export const andreSystemerLenker = (fnr, aktorId, enhet) => ({ // eslint-disable-line no-unused-vars
     tittel: 'Andre systemer',

--- a/js/menyConfig.js
+++ b/js/menyConfig.js
@@ -223,7 +223,7 @@ export function rekrutteringsBistandLenke() {
 export function sokEtterStillingLenke() {
     return {
         tittel: 'Søk etter stilling',
-        url: `https://rekrutteringsbistand${naisDomain}stillingssok?statuser=publisert&publisert=intern`,
+        url: `https://rekrutteringsbistand${naisDomain}stillingssok?standardsok`,
     };
 }
 

--- a/styles/_meny.less
+++ b/styles/_meny.less
@@ -29,6 +29,7 @@
 
   .dekorator__rad .dekorator__menyliste {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .dekorator__lenkeheader {

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -194,7 +194,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                             Søk etter stilling
                         </Lenke>
                         <Lenke href={salesforceUrl()} target="_blank">
-                            Arbeidsgiver dialog
+                            Salesforce
                         </Lenke>
                     </ul>
                 </section>

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -55,6 +55,13 @@ function k9Url(aktorId: string): string {
         return domain
     }
 }
+function salesforceUrl() {
+    if (hentMiljoFraUrl().environment === 'p') {
+        return "https://navdialog.lightning.force.com/";
+    } else {
+        return "https://navdialog--preprod.lightning.force.com/";
+    }
+}
 
 function lagHotkeys(fnr: string, aktorId: string): Array<Hotkey> {
     return [
@@ -185,6 +192,9 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                         </Lenke>
                         <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillingssok?statuser=publisert&publisert=intern`} target="_blank">
                             Søk etter stilling
+                        </Lenke>
+                        <Lenke href={salesforceUrl()} target="_blank">
+                            Arbeidsgiver dialog
                         </Lenke>
                     </ul>
                 </section>

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -190,7 +190,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                         <Lenke href={inst2()} target="_blank">
                             INST2
                         </Lenke>
-                        <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillingssok?statuser=publisert&publisert=intern`} target="_blank">
+                        <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillingssok?standardsok`} target="_blank">
                             Søk etter stilling
                         </Lenke>
                         <Lenke href={salesforceUrl()} target="_blank">

--- a/v2.1/src/styles/_meny.less
+++ b/v2.1/src/styles/_meny.less
@@ -30,6 +30,7 @@
 
     .dekorator__rad .dekorator__menyliste {
         display: flex;
+        flex-wrap: wrap;
     }
 
     .dekorator__lenkeheader {

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -200,7 +200,7 @@ function Lenker() {
                             Søk etter stilling
                         </Lenke>
                         <Lenke href={salesforceUrl()} target="_blank">
-                            Arbeidsgiver dialog
+                            Salesforce
                         </Lenke>
                     </ul>
                 </section>

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useContext} from 'react';
-import {MaybeCls} from '@nutgaard/maybe-ts';
-import {finnMiljoStreng, finnNaisMiljoStreng, hentMiljoFraUrl} from '../utils/url-utils';
-import {AppContext} from '../application';
+import { MaybeCls } from '@nutgaard/maybe-ts';
+import { finnMiljoStreng, finnNaisMiljoStreng, hentMiljoFraUrl } from '../utils/url-utils';
+import { AppContext } from '../application';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
@@ -9,7 +9,7 @@ function Lenke(props: { href: string; children: string; target?: string; }) {
     const rel = props.target ? 'noopener noreferrer' : undefined;
     return (
         <li>
-            <a {...props} className="typo-normal dekorator__menylenke" rel={rel}/>
+            <a {...props} className="typo-normal dekorator__menylenke" rel={rel} />
         </li>
     );
     /* eslint-enable jsx-a11y/anchor-has-content */
@@ -174,8 +174,10 @@ function Lenker() {
                         <Lenke href={arenaUrl(fnr)} target="_blank">
                             Arena personmappen
                         </Lenke>
-                        <Lenke href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)}
-                               target="_blank">
+                        <Lenke
+                            href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)}
+                            target="_blank"
+                        >
                             AA register
                         </Lenke>
                         <Lenke href={pesysUrl(fnr, `/psak/brukeroversikt/fnr=${fnr}`)} target="_blank">Pesys</Lenke>
@@ -195,7 +197,7 @@ function Lenker() {
                             INST2
                         </Lenke>
                         <Lenke
-                            href={`https://rekrutteringsbistand${naisDomain}/stillingssok?statuser=publisert&publisert=intern`}
+                            href={`https://rekrutteringsbistand${naisDomain}/stillingssok?standardsok`}
                             target="_blank">
                             Søk etter stilling
                         </Lenke>

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -1,7 +1,7 @@
-                                                                                                                                                                                                                                                                                                                                                                                           import React, {useCallback, useContext} from 'react';
-import { MaybeCls } from '@nutgaard/maybe-ts';
+import React, {useCallback, useContext} from 'react';
+import {MaybeCls} from '@nutgaard/maybe-ts';
 import {finnMiljoStreng, finnNaisMiljoStreng, hentMiljoFraUrl} from '../utils/url-utils';
-import { AppContext } from '../application';
+import {AppContext} from '../application';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
@@ -9,7 +9,7 @@ function Lenke(props: { href: string; children: string; target?: string; }) {
     const rel = props.target ? 'noopener noreferrer' : undefined;
     return (
         <li>
-            <a {...props} className="typo-normal dekorator__menylenke" rel={rel} />
+            <a {...props} className="typo-normal dekorator__menylenke" rel={rel}/>
         </li>
     );
     /* eslint-enable jsx-a11y/anchor-has-content */
@@ -43,12 +43,21 @@ const foreldrePengerUrl = (aktoerId: string, path: string) => aktoerId ? appDoma
 const byggArbeidssokerregistreringsURL = (fnr: string, enhet: string) => `https://arbeidssokerregistrering${finnMiljoStreng()}${naisDomain}?${fnr ? `fnr=${fnr}` : ''}${fnr && enhet ? '&' : ''}${enhet ? `enhetId=${enhet}` : ''}`;
 const arbeidstreningDomain = `https://arbeidsgiver${finnNaisMiljoStreng()}`;
 const inst2 = () => `https://inst2-web${finnNaisMiljoStreng(true)}/`;
+
 function k9Url(aktorId: string): string {
     const domain = hentMiljoFraUrl() === 'p' ? 'https://k9-los-web.nais.adeo.no/' : 'https://k9-los-web.dev.adeo.no/';
     if (aktorId) {
         return `${domain}aktoer/${aktorId}`
     } else {
         return domain
+    }
+}
+
+function salesforceUrl() {
+    if (hentMiljoFraUrl() === 'p') {
+        return "https://navdialog.lightning.force.com/";
+    } else {
+        return "https://navdialog--preprod.lightning.force.com/";
     }
 }
 
@@ -83,10 +92,10 @@ function Lenker() {
         .flatMap((resp) => MaybeCls.of(resp.identer))
         .filter((identer) => identer.some((ident) => ident.gjeldende))
         .map((identer) => identer.find((ident) => ident.gjeldende)!)
-        .map(({ ident }) => ident)
+        .map(({ident}) => ident)
         .withDefault('');
 
-    const hotkeys = useCallback(lagHotkeys, [fnr, aktorId])(fnr,  aktorId);
+    const hotkeys = useCallback(lagHotkeys, [fnr, aktorId])(fnr, aktorId);
     useHotkeys(hotkeys);
 
     if (!context.apen.value) {
@@ -165,7 +174,8 @@ function Lenker() {
                         <Lenke href={arenaUrl(fnr)} target="_blank">
                             Arena personmappen
                         </Lenke>
-                        <Lenke href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)} target="_blank">
+                        <Lenke href={modappDomain(`/aareg-web/?rolle=arbeidstaker&${fnr ? `ident=${fnr}` : ''}`)}
+                               target="_blank">
                             AA register
                         </Lenke>
                         <Lenke href={pesysUrl(fnr, `/psak/brukeroversikt/fnr=${fnr}`)} target="_blank">Pesys</Lenke>
@@ -184,8 +194,13 @@ function Lenker() {
                         <Lenke href={inst2()} target="_blank">
                             INST2
                         </Lenke>
-                        <Lenke href={`https://rekrutteringsbistand${naisDomain}/stillingssok?statuser=publisert&publisert=intern`} target="_blank">
+                        <Lenke
+                            href={`https://rekrutteringsbistand${naisDomain}/stillingssok?statuser=publisert&publisert=intern`}
+                            target="_blank">
                             Søk etter stilling
+                        </Lenke>
+                        <Lenke href={salesforceUrl()} target="_blank">
+                            Arbeidsgiver dialog
                         </Lenke>
                     </ul>
                 </section>

--- a/v2/src/styles/_meny.less
+++ b/v2/src/styles/_meny.less
@@ -28,6 +28,7 @@
 
     .dekorator__rad .dekorator__menyliste {
         display: flex;
+        flex-wrap: wrap;
     }
 
     .dekorator__lenkeheader {


### PR DESCRIPTION
for nå legger vi bare til direkte lenke til SF, de må selv håndtere evt feilmelding og visning av riktig innhold basert på hvor bruker kommer fra siden de ikke ønsker noen form for dyplenking nå.

I fremtiden skal vi sannsynligvis også sende med aktørid for å sette bruker i kontekst ved bytte av system, og da vil problemene rundt hvilken visning saksbehandler ønsker bli forverret, men dette må SF da løse på sin side.
Eksempel vis om saksbehandler ønsker visning av arbeidsgiver-dialog og modia har en bruker i kontekst. 

![image](https://user-images.githubusercontent.com/1413417/108833182-c000fb00-75cc-11eb-93ca-a5b2a45f423c.png)
