### PR TITLE
Endre domene for url for app Syfomoteoversikt

### DIFF
--- a/js/menyConfig.js
+++ b/js/menyConfig.js
@@ -117,7 +117,7 @@ export const funksjonsomradeLenker = (fnr, enhet) => [
             },
             {
                 tittel: 'Dialogmøteoversikt',
-                url: `https://syfomoteoversikt${naisDomain}`,
+                url: `https://syfomoteoversikt${naisInternNavDomain}`,
             },
             {
                 tittel: 'Finn fastlege',

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -158,7 +158,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                         <ul className="dekorator__menyliste">
                             <Lenke href={`https://syfooversikt${naisInternNavDomain}/enhet`}>Enhetens oversikt</Lenke>
                             <Lenke href={`https://syfooversikt${naisInternNavDomain}/minoversikt`}>Min oversikt</Lenke>
-                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøteoversikt</Lenke>
+                            <Lenke href={`https://syfomoteoversikt${naisInternNavDomain}/`}>Dialogmøteoversikt</Lenke>
                             <Lenke href={`https://finnfastlege${naisInternNavDomain}/fastlege/`}>Finn fastlege</Lenke>
                             <Lenke href={`https://syfomodiaperson${naisDomain}/sykefravaer/${fnr ? fnr : ''}`}>
                                 Sykmeldt enkeltperson

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -161,7 +161,7 @@ function Lenker() {
                         <ul className="dekorator__menyliste">
                             <Lenke href={`https://syfooversikt${naisInternNavDomain}/enhet`}>Enhetens oversikt</Lenke>
                             <Lenke href={`https://syfooversikt${naisInternNavDomain}/minoversikt`}>Min oversikt</Lenke>
-                            <Lenke href={`https://syfomoteoversikt${naisDomain}/`}>Dialogmøteoversikt</Lenke>
+                            <Lenke href={`https://syfomoteoversikt${naisInternNavDomain}/`}>Dialogmøteoversikt</Lenke>
                             <Lenke href={`https://finnfastlege${naisInternNavDomain}/fastlege/`}>Finn fastlege</Lenke>
                             <Lenke href={`https://syfomodiaperson${naisDomain}/sykefravaer/${fnr ? fnr : ''}`}>
                                 Sykmeldt enkeltperson


### PR DESCRIPTION
Syfomoteoversikt flytter til nyeste NAIS-domenet og derfor trenger url å reflekere dette.