### PR TITLE
[KAIZEN-0] sende bruker via login før man når arbeidssokerregistrering

### DIFF
--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -44,6 +44,7 @@ const pesysUrl = (fnr: string, path: string) => (fnr ? pesysDomain(path) : pesys
 const gosysUrl = (fnr: string, path: string) => fnr ? gosysDomain(path) : gosysDomain('/gosys/');
 const foreldrePengerUrl = (aktoerId: string, path: string) => aktoerId ? appDomain(path) : appDomain('/fpsak/');
 const byggArbeidssokerregistreringsURL = (fnr: string, enhet: string) => `https://arbeidssokerregistrering${finnMiljoStreng()}${naisDomain}?${fnr ? `fnr=${fnr}` : ''}${fnr && enhet ? '&' : ''}${enhet ? `enhetId=${enhet}` : ''}`;
+const arbeidssokerregistreringLoginUrl = (fnr: string, enhet: string) => `https://veilarblogin${finnMiljoStreng()}${naisDomain}veilarblogin/api/start?url=${encodeURIComponent(byggArbeidssokerregistreringsURL(fnr, enhet))}`
 const arbeidstreningDomain = `https://arbeidsgiver${finnNaisMiljoStreng()}`;
 const inst2 = () => `https://inst2-web${finnNaisMiljoStreng(true)}/`;
 function k9Url(aktorId: string): string {
@@ -144,7 +145,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                             <Lenke href={appDomain(`/veilarbpersonflatefs/${fnr ? fnr : ''}?enhet=${enhet}`)}>
                                 Aktivitetsplan
                             </Lenke>
-                            <Lenke href={byggArbeidssokerregistreringsURL(fnr, enhet)}>
+                            <Lenke href={arbeidssokerregistreringLoginUrl(fnr, enhet)}>
                                 Registrer arbeidssøker
                             </Lenke>
                             <Lenke href={`${arbeidstreningDomain}/tiltaksgjennomforing`}>


### PR DESCRIPTION
Ved endring av modiapersonoversikt til å bruke `modia_ID_token` så vil man ikke lengre være logget inn i arbeidssøkerregistrering-appen
om man har vært logget inn i modiapersonoversikt. Siden arbeidssokerregistrering ikke håndterer innlogging selv må vi derfor sende vi manuelt via veilarblogin.

@AlexGaard Ser du noen utfordringer med å gjøre dette i produksjon? Ekstra trafikk mot veilarblogin etc?