### PR TITLE
[KAIZEN-0] ikke sende med `Referer` header

### DIFF
--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -7,6 +7,7 @@ import {useEnhetContextvalueState, useFnrContextvalueState} from "../hooks/use-c
 
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
+    /* eslint-disable jsx-a11y/anchor-has-content */
     return (
         <li>
             <a {...props} className="typo-normal dekorator__menylenke" rel="noopener noreferrer" />

--- a/v2.1/src/components/lenker.tsx
+++ b/v2.1/src/components/lenker.tsx
@@ -7,11 +7,9 @@ import {useEnhetContextvalueState, useFnrContextvalueState} from "../hooks/use-c
 
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
-    /* eslint-disable jsx-a11y/anchor-has-content */
-    const rel = props.target ? 'noopener noreferrer' : undefined;
     return (
         <li>
-            <a {...props} className="typo-normal dekorator__menylenke" rel={rel}/>
+            <a {...props} className="typo-normal dekorator__menylenke" rel="noopener noreferrer" />
         </li>
     );
     /* eslint-enable jsx-a11y/anchor-has-content */

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -5,11 +5,9 @@ import { AppContext } from '../application';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
-    /* eslint-disable jsx-a11y/anchor-has-content */
-    const rel = props.target ? 'noopener noreferrer' : undefined;
     return (
         <li>
-            <a {...props} className="typo-normal dekorator__menylenke" rel={rel} />
+            <a {...props} className="typo-normal dekorator__menylenke" rel="noopener noreferrer" />
         </li>
     );
     /* eslint-enable jsx-a11y/anchor-has-content */

--- a/v2/src/components/lenker.tsx
+++ b/v2/src/components/lenker.tsx
@@ -5,6 +5,7 @@ import { AppContext } from '../application';
 import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
+    /* eslint-disable jsx-a11y/anchor-has-content */
     return (
         <li>
             <a {...props} className="typo-normal dekorator__menylenke" rel="noopener noreferrer" />


### PR DESCRIPTION
Ded overgang til andre løsningen sender browseren automatisk en `Referer` http-header som inneholder urlen til siden man kom fra.

Dette blir muligens plukket opp av amplitude og logget, noe som ikke er ønskelig. Vi forsøker derfor å kvitte oss med dette for å se om innslagene i amplitude også roer seg ned.
