### PR TITLE
[KAIZEN-0] gjøre redirect til aareg via proxy

### DIFF
--- a/src/application.tsx
+++ b/src/application.tsx
@@ -61,7 +61,7 @@ function Application(props: ApplicationProps) {
     return (
         <header className="dekorator" ref={ref}>
             <Banner apen={apen} appname={props.appname} />
-            {isInitialized && <Lenker apen={apen} />}
+            {isInitialized && <Lenker apen={apen} proxyConfig={props.useProxy || false}/>}
             <Feilmelding />
             {isInitialized && <NyEnhetContextModal />}
             {isInitialized && <NyBrukerContextModal />}

--- a/src/components/lenker.tsx
+++ b/src/components/lenker.tsx
@@ -4,6 +4,8 @@ import useHotkeys, {erAltOg, Hotkey, openUrl} from "../hooks/use-hotkeys";
 import {WrappedState} from "../hooks/use-wrapped-state";
 import {useInitializedState} from "../hooks/use-initialized-state";
 import {useEnhetContextvalueState, useFnrContextvalueState} from "../hooks/use-contextvalue-state";
+import {ProxyConfig} from "../domain";
+import {lagModiacontextholderUrl} from "../redux/api";
 
 
 function Lenke(props: { href: string; children: string; target?: string; }) {
@@ -99,8 +101,12 @@ function lagHotkeys(fnr: string, aktorId: string): Array<Hotkey> {
     ];
 }
 
+interface Props {
+    apen: WrappedState<boolean>;
+    proxyConfig: ProxyConfig;
+}
 
-function Lenker({apen}: { apen: WrappedState<boolean> }) {
+function Lenker(props: Props) {
     const fnr = useFnrContextvalueState().withDefault('');
     const enhet = useEnhetContextvalueState().withDefault('');
     const aktorId: string = useInitializedState((state) => state.data.aktorId)
@@ -110,9 +116,10 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
     const hotkeys = useCallback(lagHotkeys, [fnr, aktorId])(fnr, aktorId);
     useHotkeys(hotkeys);
 
-    if (!apen.value) {
+    if (!props.apen.value) {
         return null;
     }
+    const modiacontextholderUrl = lagModiacontextholderUrl(props.proxyConfig);
 
     return (
         <div className="dekorator__nav dekorator__nav--apen">
@@ -186,7 +193,7 @@ function Lenker({apen}: { apen: WrappedState<boolean> }) {
                         <Lenke href={arenaUrl(fnr)} target="_blank">
                             Arena personmappen
                         </Lenke>
-                        <Lenke href={appDomain('/modiacontextholder/redirect/aaregisteret')} target="_blank">
+                        <Lenke href={`${modiacontextholderUrl}/redirect/aaregisteret`} target="_blank">
                             AA register
                         </Lenke>
                         <Lenke href={pesysUrl(fnr, `/psak/brukeroversikt/fnr=${fnr}`)} target="_blank">Pesys</Lenke>

--- a/src/redux/api.test.ts
+++ b/src/redux/api.test.ts
@@ -5,20 +5,20 @@ describe('api', () => {
     describe('modiacontextholder-url', () => {
         it('skal ha riktig url ved kjøring lokalt', () => {
             withLocation('localhost', () => {
-                expect(lagModiacontextholderUrl()).toBe('/modiacontextholder/api');
+                expect(lagModiacontextholderUrl()).toBe('/modiacontextholder');
             });
         });
 
         it('skal ha riktig nais-url ved kjøring på nais-dev.intern', () => {
             withLocation('https://navn-q6.dev.intern.nav.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder-q6.dev.intern.nav.no/modiacontextholder/api'
+                    'https://modiacontextholder-q6.dev.intern.nav.no/modiacontextholder'
                 );
             });
 
             withLocation('https://navn.dev.intern.nav.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder-q0.dev.intern.nav.no/modiacontextholder/api'
+                    'https://modiacontextholder-q0.dev.intern.nav.no/modiacontextholder'
                 );
             });
         });
@@ -26,7 +26,7 @@ describe('api', () => {
         it('skal ha riktig nais-url ved kjøring på nais.intern', () => {
             withLocation('https://navn.intern.nav.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder.intern.nav.no/modiacontextholder/api'
+                    'https://modiacontextholder.intern.nav.no/modiacontextholder'
                 );
             });
         });
@@ -34,13 +34,13 @@ describe('api', () => {
         it('skal ha riktig nais-url ved kjøring på nais-preprod', () => {
             withLocation('https://navn-q6.nais.preprod.local/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder-q6.nais.preprod.local/modiacontextholder/api'
+                    'https://modiacontextholder-q6.nais.preprod.local/modiacontextholder'
                 );
             });
 
             withLocation('https://navn.nais.preprod.local/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder-q0.nais.preprod.local/modiacontextholder/api'
+                    'https://modiacontextholder-q0.nais.preprod.local/modiacontextholder'
                 );
             });
         });
@@ -48,7 +48,7 @@ describe('api', () => {
         it('skal ha riktig nais-url ved kjøring på nais-prod', () => {
             withLocation('https://navn-q.nais.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://modiacontextholder.nais.adeo.no/modiacontextholder/api'
+                    'https://modiacontextholder.nais.adeo.no/modiacontextholder'
                 );
             });
         });
@@ -56,7 +56,7 @@ describe('api', () => {
         it('skal ha riktig url ved kjøring på app-XX.adeo.no', () => {
             withLocation('https://app-q6.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://app-q6.adeo.no/modiacontextholder/api'
+                    'https://app-q6.adeo.no/modiacontextholder'
                 );
             });
         });
@@ -64,7 +64,7 @@ describe('api', () => {
         it('skal ha riktig url ved kjøring på app-XX.dev.adeo.no', () => {
             withLocation('https://app-q6.dev.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://app-q6.dev.adeo.no/modiacontextholder/api'
+                    'https://app-q6.dev.adeo.no/modiacontextholder'
                 );
             });
         });
@@ -72,7 +72,7 @@ describe('api', () => {
         it('skal ha riktig url ved kjøring på app.adeo.no', () => {
             withLocation('https://app.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://app.adeo.no/modiacontextholder/api'
+                    'https://app.adeo.no/modiacontextholder'
                 );
             });
         });
@@ -80,7 +80,7 @@ describe('api', () => {
         it('skal bruke domene fra proxy config', () => {
             withLocation('https://app.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl('https://vg.no')).toBe(
-                    'https://vg.no/modiacontextholder/api'
+                    'https://vg.no/modiacontextholder'
                 );
             });
         });
@@ -88,7 +88,7 @@ describe('api', () => {
         it('skal bruke relativ path om proxyconfig er true', () => {
             withLocation('https://app.adeo.no/contextpath', () => {
                 expect(lagModiacontextholderUrl(true)).toBe(
-                    '/modiacontextholder/api'
+                    '/modiacontextholder'
                 );
             });
         });
@@ -96,7 +96,7 @@ describe('api', () => {
         it('skal ha fallback til prod om alt feiler', () => {
             withLocation('https://vg.no/contextpath', () => {
                 expect(lagModiacontextholderUrl()).toBe(
-                    'https://app.adeo.no/modiacontextholder/api'
+                    'https://app.adeo.no/modiacontextholder'
                 );
             });
         });

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -23,40 +23,40 @@ export function lagModiacontextholderUrl(proxyConfig: ProxyConfig = false): stri
     const envString = urlEnv.envclass === 'p' ? '' : `-${urlEnv.environment}`;
 
     if (typeof proxyConfig === 'string') {
-        return `${proxyConfig}/modiacontextholder/api`;
+        return `${proxyConfig}/modiacontextholder`;
     } else if (proxyConfig) {
-        return '/modiacontextholder/api';
+        return '/modiacontextholder';
     }
 
     switch (urlEnv.urlformat) {
         case UrlFormat.ADEO:
-            return `https://app${envString}.adeo.no/modiacontextholder/api`;
+            return `https://app${envString}.adeo.no/modiacontextholder`;
         case UrlFormat.NAIS:
             if (urlEnv.envclass === 'p') {
-                return 'https://modiacontextholder.nais.adeo.no/modiacontextholder/api';
+                return 'https://modiacontextholder.nais.adeo.no/modiacontextholder';
             } else {
-                return `https://modiacontextholder${envString}.nais.preprod.local/modiacontextholder/api`
+                return `https://modiacontextholder${envString}.nais.preprod.local/modiacontextholder`
             }
         case UrlFormat.DEV_ADEO:
-            return `https://app${envString}.dev.adeo.no/modiacontextholder/api`;
+            return `https://app${envString}.dev.adeo.no/modiacontextholder`;
         case UrlFormat.NAV_NO:
             if (urlEnv.envclass === 'p') {
-                return 'https://modiacontextholder.intern.nav.no/modiacontextholder/api';
+                return 'https://modiacontextholder.intern.nav.no/modiacontextholder';
             } else {
-                return `https://modiacontextholder${envString}.dev.intern.nav.no/modiacontextholder/api`;
+                return `https://modiacontextholder${envString}.dev.intern.nav.no/modiacontextholder`;
             }
         case UrlFormat.LOCAL:
-            return '/modiacontextholder/api';
+            return '/modiacontextholder';
     }
 }
 function lagUrls(proxyConfig: ProxyConfig) {
     const modiacontextholderUrl = lagModiacontextholderUrl(proxyConfig);
     return {
-        aktivEnhetUrl: `${modiacontextholderUrl}/context/aktivenhet`,
-        aktivBrukerUrl: `${modiacontextholderUrl}/context/aktivbruker`,
-        contextUrl: `${modiacontextholderUrl}/context`,
-        saksbehandlerUrl: `${modiacontextholderUrl}/decorator`,
-        aktorIdUrl: (fnr: string) => `${modiacontextholderUrl}/decorator/aktor/${fnr}`
+        aktivEnhetUrl: `${modiacontextholderUrl}/api/context/aktivenhet`,
+        aktivBrukerUrl: `${modiacontextholderUrl}/api/context/aktivbruker`,
+        contextUrl: `${modiacontextholderUrl}/api/context`,
+        saksbehandlerUrl: `${modiacontextholderUrl}/api/decorator`,
+        aktorIdUrl: (fnr: string) => `${modiacontextholderUrl}/api/decorator/aktor/${fnr}`
     };
 }
 export let urls = lagUrls(false);


### PR DESCRIPTION
rekrutteringsbistand bruker proxy mot modiacontextholder, for å sikre at innlogget bruker blir videresendt må derfor redirecten gå gjennom denne proxy'en.

Dette oppnåes ved å bruke proxy-configen ved utledningen av urlen til aareg
