### PR TITLE
Beslutteroversikt går over til gcp/azureAd

### DIFF
--- a/src/components/lenker.tsx
+++ b/src/components/lenker.tsx
@@ -146,7 +146,7 @@ function Lenker(props: Props) {
                             <Lenke href={appDevDomain(`/veilarbportefoljeflatefs/portefolje?clean&enhet=${enhet}`)}>
                                 Min oversikt
                             </Lenke>
-                            <Lenke href={appDomain(`/beslutteroversikt`)}>
+                            <Lenke href={`https://beslutteroversikt${finnNaisInternNavMiljoStreng()}.intern.nav.no/`}>
                                 Kvalitetssikring 14a
                             </Lenke>
                             <Lenke href={appDomain(`/veilarbpersonflatefs/${fnr ? fnr : ''}?enhet=${enhet}`)}>


### PR DESCRIPTION
Denne kan lukkes: https://github.com/navikt/internarbeidsflatedecorator/pull/328
Vi ender opp med å ikke kjøre intern og Adeo samtidig, men hopper fult over med en og en app.