### PR TITLE
Ny url for tiltaksgjennomforing

### DIFF
--- a/src/components/lenker.tsx
+++ b/src/components/lenker.tsx
@@ -53,7 +53,6 @@ function arbeidssokerregistreringURL(fnr: string, enhet: string) {
     const queryParams = `?${fnr ? `fnr=${fnr}` : ''}${fnr && enhet ? '&' : ''}${enhet ? `enhetId=${enhet}` : ''}`;
     return `https://arbeidssokerregistrering${finnNaisInternNavMiljoStreng()}${queryParams}`;
 }
-const arbeidstreningDomain = `https://arbeidsgiver${finnNaisMiljoStreng()}`;
 const inst2 = () => `https://inst2-web${finnNaisMiljoStreng(true)}/`;
 function k9Url(aktorId: string): string {
     const miljo = hentMiljoFraUrl();
@@ -154,7 +153,7 @@ function Lenker(props: Props) {
                             <Lenke href={arbeidssokerregistreringURL(fnr, enhet)}>
                                 Registrer arbeidssøker
                             </Lenke>
-                            <Lenke href={`${arbeidstreningDomain}/tiltaksgjennomforing`}>
+                            <Lenke href={`https://tiltaksgjennomforing${naisInternNavDomain}/tiltaksgjennomforing`} target="_blank">
                                 Tiltaksgjennomføring - avtaler
                             </Lenke>
                         </ul>

--- a/src/components/lenker.tsx
+++ b/src/components/lenker.tsx
@@ -153,7 +153,7 @@ function Lenker(props: Props) {
                             <Lenke href={arbeidssokerregistreringURL(fnr, enhet)}>
                                 Registrer arbeidssøker
                             </Lenke>
-                            <Lenke href={`https://tiltaksgjennomforing${naisInternNavDomain}/tiltaksgjennomforing`} target="_blank">
+                            <Lenke href={`https://tiltaksgjennomforing${naisInternNavDomain}/tiltaksgjennomforing`}>
                                 Tiltaksgjennomføring - avtaler
                             </Lenke>
                         </ul>


### PR DESCRIPTION
Vi endrer intern url til tiltaksgjennomføring da vi migrert til gcp.

Nye urler er:
Dev: https://tiltaksgjennomforing.dev.intern.nav.no/tiltaksgjennomforing
Prod: https://tiltaksgjennomforing.intern.nav.no/tiltaksgjennomforing

Vi er ikke helt klare, men gir en ping når dette kan merges.