### PR TITLE
[KAIZEN-0] Ny ingress for modia oversikten i dev

### DIFF
--- a/src/components/lenker.tsx
+++ b/src/components/lenker.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {
     finnMiljoStreng,
-    finnNaisInternNavMiljoStreng,
+    finnNaisInternNavMiljoStreng, finnNaisInternNavMiljoStrengNyIngress,
     finnNaisMiljoStreng,
     hentMiljoFraUrl
 } from '../utils/url-utils';
@@ -154,16 +154,16 @@ function Lenker(props: Props) {
                     <section className="dekorator__kolonne">
                         <h2 className="dekorator__lenkeheader">Arbeidsrettet oppfølging</h2>
                         <ul className="dekorator__menyliste">
-                            <Lenke href={`https://veilarbportefoljeflate${finnNaisInternNavMiljoStreng()}/enhet?clean&enhet=${enhet}`}>
+                            <Lenke href={`https://veilarbportefoljeflate${finnNaisInternNavMiljoStrengNyIngress()}/enhet?clean&enhet=${enhet}`}>
                                 Enhetens oversikt
                             </Lenke>
-                            <Lenke href={`https://veilarbportefoljeflate${finnNaisInternNavMiljoStreng()}/portefolje?clean&enhet=${enhet}`}>
+                            <Lenke href={`https://veilarbportefoljeflate${finnNaisInternNavMiljoStrengNyIngress()}/portefolje?clean&enhet=${enhet}`}>
                                 Min oversikt
                             </Lenke>
                             <Lenke href={`https://beslutteroversikt${finnNaisInternNavMiljoStreng()}`}>
                                 Kvalitetssikring 14a
                             </Lenke>
-                            <Lenke href={`https://veilarbpersonflate${finnNaisInternNavMiljoStreng()}/${fnr ? fnr : ''}?enhet=${enhet}`}>
+                            <Lenke href={`https://veilarbpersonflate${finnNaisInternNavMiljoStrengNyIngress()}/${fnr ? fnr : ''}?enhet=${enhet}`}>
                                 Aktivitetsplan
                             </Lenke>
                             <Lenke href={arbeidssokerregistreringURL(fnr, enhet)}>

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -140,3 +140,12 @@ export function finnNaisInternNavMiljoStreng(envNamespace: boolean = false) {
     }
     return `${prefix}.intern.nav.no`;
 }
+
+export function finnNaisInternNavMiljoStrengNyIngress(envNamespace: boolean = false) {
+    const miljo = hentMiljoFraUrl().environment;
+    const prefix = envNamespace && miljo !== 'p' ? `-${miljo}` : '';
+    if (miljo !== 'p') {
+        return `${prefix}.intern.dev.nav.no`;
+    }
+    return finnNaisInternNavMiljoStreng(envNamespace);
+}


### PR DESCRIPTION
Ingressene i dev-gcp har blitt oppdatert fra `intern.dev.nav.no` til `dev.intern.nav.no`.