### PR TITLE
Ikke feil helt når context ikke svarer

### DIFF
--- a/packages/internarbeidsflate-decorator-v3/src/store/FnrValueManager.ts
+++ b/packages/internarbeidsflate-decorator-v3/src/store/FnrValueManager.ts
@@ -88,14 +88,13 @@ export class FnrValueManager extends ContextValueManager {
   };
 
   readonly changeFnrLocallyAndExternally = async (newFnr?: string) => {
-    const revert = this.optimisticUpdate('fnr');
+    this.optimisticUpdate('fnr');
     this.changeFnrLocally(newFnr);
     const res = await this.contextHolderApi.changeFnr(newFnr);
     if (res.error) {
       this.#errorMessageManager.addErrorMessage(
         PredefiniertFeilmeldinger.OPPDATER_BRUKER_CONTEXT_FEILET,
       );
-      revert();
     }
   };
 
@@ -127,9 +126,9 @@ export class FnrValueManager extends ContextValueManager {
     }
   };
 
-  readonly clearFnr = () => {
+  readonly clearFnr = async () => {
     this.changeFnrLocally();
-    this.clearFnrExternally();
+    await this.clearFnrExternally();
     this.#propsUpdateHandler.clearOldValue('fnr');
   };
 


### PR DESCRIPTION
Ved feil på oppdateringer i context nå vil ikke dekoratøren endre fnr
lokalt heller. Dette gjør at menyen blir vanskelig å bruke dersom
context ikke funker. Med denne så ignorerer vi feilen og endrer fnr
lokalt uansett slik at det faktisk er mulig å endre bruker uavhengig om
det oppdateres i context.
