### PR TITLE
Legg til urlformat til veilarbportefoljeUrl

### DIFF
--- a/packages/internarbeidsflate-decorator-v3/src/utils/urlUtils.ts
+++ b/packages/internarbeidsflate-decorator-v3/src/utils/urlUtils.ts
@@ -191,7 +191,7 @@ export const buildLinks = ({
       url: modiaUrl(fnr, `/person`, environment, urlFormat),
     },
     veilarbportefoljeUrl: {
-      url: `https://veilarbportefoljeflate${naisDomain(environment)}`,
+      url: `https://veilarbportefoljeflate${naisDomain(environment, urlFormat)}`,
     },
     veilarbpersonUrl: {
       url: veilarbpersonflateUrl({ environment, urlFormat }),


### PR DESCRIPTION
Vi legger ansatt ingressen til veilarbportefoljeflatefs sånn at veileder kunne få tilgang til appen uten å bruke naisdevice