### PR TITLE
Add stale-while-revalidate to cache control

### DIFF
--- a/.github/workflows/main-v3.yaml
+++ b/.github/workflows/main-v3.yaml
@@ -96,4 +96,4 @@ jobs:
           destination: /internarbeidsflate-decorator-v3/prod/${{ env.CDN_PATH }}
           cache_invalidation: true
           headers: |-
-            cache-control: public, max-age=600
+            cache-control: public, max-age=600, stale-while-revalidate=60

--- a/.github/workflows/main-v3.yaml
+++ b/.github/workflows/main-v3.yaml
@@ -96,4 +96,4 @@ jobs:
           destination: /internarbeidsflate-decorator-v3/prod/${{ env.CDN_PATH }}
           cache_invalidation: true
           headers: |-
-            cache-control: public, max-age=600, stale-while-revalidate=60
+            cache-control: public, max-age=600, stale-while-revalidate=300


### PR DESCRIPTION
Vi ser at henting av filer fra CDN av og til tar veldig lang tid (10 sek!!!). Har ikke funnet ut hvofor det skjer men prøver å komme oss rundt problemet med å gjøre henting av oppdaterte filer mens man bruker gammel versjon ved hjelp av å sette stale-while-revalidate i cache-control headeren. Det skal gjøre at når filene blir "stale" (utdatert) så brukes fortsatt gamle filer mens nye filer hentes i backgrunnen for et gitt interval, her 5min etter at filene blir stale. Etter denne perioden blir filene alltid henter fra CDN uten noe cache

![image](https://github.com/user-attachments/assets/8809a419-07f3-4866-b084-055ce423670d)
