### PR TITLE
Update INST2 URL to use new domain

### DIFF
--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -249,7 +249,7 @@ export const buildLinks = ({
       url: `https://rekrutteringsbistand${naisDomain(environment)}`,
     },
     INST2: {
-      url: `https://inst2-web${naisAdeoDomain(environment)}`,
+      url: `https://institusjon-opphold-web${naisDomain(environment)}`,
     },
     modiaSosialhjelp: {
       url: `https://sosialhjelp-modia${naisDomain(


### PR DESCRIPTION
Vi har migrert inst2-web til GCP og adeo url er ikke lenger i bruk. [Tråd i Slack](https://nav-it.slack.com/archives/CLJJKQEHY/p1761915629313319).