### PR TITLE
Hindre style leak i document.body

### DIFF
--- a/src/Decorator.tsx
+++ b/src/Decorator.tsx
@@ -43,6 +43,9 @@ const Decorator: React.FC<PropsWithChildren<DecoratorProps>> = (props) => {
   );
 
   return (
+    /* ShadowRoot er ikke en subtype av HTMLElement i TypeScript, selv om den har alle nødvendige DOM-metoder.
+        Vi må derfor caste via unknown. Provider bruker rootElement som portal for Modal-komponenter,
+        slik at de rendres inni shadow-roten og får med seg stilene fra adoptedStyleSheets. */
     <Provider rootElement={props.shadowRoot as unknown as HTMLElement}>
       <div className="dekorator">
         <div

--- a/src/Decorator.tsx
+++ b/src/Decorator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { type PropsWithChildren, useMemo } from 'react';
-import './index.bundled.css';
+import { Provider } from '@navikt/ds-react';
 import Banner from './components/Banner';
 import ErrorMessage from './components/ErrorMessageDisplay';
 import Menu from './components/Menu';
@@ -43,17 +43,22 @@ const Decorator: React.FC<PropsWithChildren<DecoratorProps>> = (props) => {
   );
 
   return (
-    <div className="dekorator">
-      <div className="dekorator" data-theme="internarbeidsflatedecorator-theme">
-        <header ref={ref} className="dr:font-arial dr:text-white">
-          <Banner />
-          <Menu />
-          <ErrorMessage />
-        </header>
+    <Provider rootElement={props.shadowRoot as unknown as HTMLElement}>
+      <div className="dekorator">
+        <div
+          className="dekorator"
+          data-theme="internarbeidsflatedecorator-theme"
+        >
+          <header ref={ref} className="dr:font-arial dr:text-white">
+            <Banner />
+            <Menu />
+            <ErrorMessage />
+          </header>
+        </div>
+        <NewUserModal />
+        <NewEnhetModal />
       </div>
-      <NewUserModal />
-      <NewEnhetModal />
-    </div>
+    </Provider>
   );
 };
 

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import './index.bundled.css';
 import classNames from 'classnames';
 import useAppLogic from './hooks/useAppLogic';
 import { AppProps } from './types/AppProps';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './index.bundled.css';
 import Navspa from '@navikt/navspa';
 import Decorator from './Decorator';
 import LandingPage from './LandingPage';

--- a/src/types/AppProps.ts
+++ b/src/types/AppProps.ts
@@ -15,6 +15,8 @@ interface DomainProps {
   onFnrChanged?: (fnr?: string | null) => void;
   onLinkClick?: (link: { text: string; url: string }) => void;
   websocketUrl?: string | undefined;
+  /** Brukt internt av web comppnenten for å scope modal portals inn i shadow root. */
+  shadowRoot?: ShadowRoot;
 
   ignoreExternalFnr?: boolean;
   ignoreExternalEnhet?: boolean;

--- a/src/types/AppProps.ts
+++ b/src/types/AppProps.ts
@@ -15,7 +15,7 @@ interface DomainProps {
   onFnrChanged?: (fnr?: string | null) => void;
   onLinkClick?: (link: { text: string; url: string }) => void;
   websocketUrl?: string | undefined;
-  /** Brukt internt av web comppnenten for å scope modal portals inn i shadow root. */
+  /** Brukt internt av web componenten for å scope modal portals inn i shadow root. */
   shadowRoot?: ShadowRoot;
 
   ignoreExternalFnr?: boolean;

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -173,6 +173,7 @@ abstract class DecoratorBase extends HTMLElement {
       onEnhetChanged: this.handleEnhetChanged,
       onFnrChanged: this.handleFnrChanged,
       onLinkClick: this.handleLinkClick,
+      shadowRoot: this.shadowRoot ?? undefined,
     };
   }
 


### PR DESCRIPTION
CSSen blei lekket ved at den blei lagt til i host-appen sin `<head>`. Dette var pga at bundlen blei loadet inn i `landingpage.tsx`. Dette er fjerna, men for at modalen skal få styling så må me sende shadowRoot inn i ein aksel-provider.  Modalene rendres inn i shadow-roten i staden for til document.body 